### PR TITLE
View Content and Communities, Request to Join Communities, and Approve/Deny Requests

### DIFF
--- a/client/src/actions/recentPostsActions.js
+++ b/client/src/actions/recentPostsActions.js
@@ -62,42 +62,10 @@ export const receivePosts = (section, data) => ({
  *  @param {function} dispatch Redux dispatch function
  *  @returns {function} Dispatches returned action object
  */
-const fetchPosts = (section, user) => dispatch => {
+export const fetchPosts = (section, user) => dispatch => {
   dispatch(requestPosts(section));
   return getRecentActivity(user, 10) //limit 10 'my communities'
     .then(data => {
       dispatch(receivePosts(section, data.data));
     });
-}
-
-/**
- *  Function to fetch the recent activity from the database.
- *
- *  @param {object} state Redux state
- *  @param {string} section Section selected
- *  @returns {bool} Determines if a fetch should be done
- */
-const shouldFetchRecent = (state, section) => {
-  const activity = state.recentActivity[section];
-
-  if (!activity) {
-    return true;
-  }
-  if (activity.isFetching) {
-    return false;
-  }
-  return activity.didInvalidate;
-}
-
-/**
- *  Function to fetch the recent activity from the database.
- *
- *  @param {function} dispatch Redux dispatch function
- *  @param {function} getState Redux funtion to get the store state
- *  @returns {function} Dispatches returned action object
- */
-export const fetchRecentIfNeeded = (section, user) => (dispatch, getState) => {
-  if (shouldFetchRecent(getState(), section)) {
-    return dispatch(fetchPosts(section, user));
-  }
 }

--- a/client/src/components/ErrorBoundary/ErrorBoundary.js
+++ b/client/src/components/ErrorBoundary/ErrorBoundary.js
@@ -30,17 +30,12 @@ class ErrorBoundary extends Component {
   }
 
   render() {
-    const {error, errorInfo} = this.state;
+    const {errorInfo} = this.state;
     if (errorInfo) {
       // Error path
       return (
         <div>
           <h2>Something went wrong.</h2>
-          <details style={{ whiteSpace: 'pre-wrap' }}>
-            {error && error.toString()}
-            <br />
-            {errorInfo.componentStack}
-          </details>
         </div>
       );
     }

--- a/client/src/components/pages/Groups/GroupSummary.js
+++ b/client/src/components/pages/Groups/GroupSummary.js
@@ -2,6 +2,16 @@ import React from 'react';
 
 import GroupsRecent from './GroupsRecent';
 
+/**
+ *  All community display components are located here.
+ *
+ *  GroupRecent shows communities with recent activity in them.
+ *
+ *  @param {boolean} isAuth Determines if user is authenticated
+ *  @param {array} groupsActivity Data for active groups
+ *  @param {string} groupRequested The name of the group being requested to join
+ *  @param {function} onJoinGroup Handles a join request
+ */
 const GroupSummary = ({isAuth, groupsActivity, groupRequested, onJoinGroup}) => (
   <GroupsRecent
     isAuth={isAuth}

--- a/client/src/components/pages/Groups/GroupSummary.js
+++ b/client/src/components/pages/Groups/GroupSummary.js
@@ -1,6 +1,8 @@
 import React from 'react';
+import {Grid, Segment} from "semantic-ui-react";
 
 import GroupsRecent from './GroupsRecent';
+import GroupsCreated from './GroupsCreated';
 
 /**
  *  All community display components are located here.
@@ -8,17 +10,33 @@ import GroupsRecent from './GroupsRecent';
  *  GroupRecent shows communities with recent activity in them.
  *
  *  @param {boolean} isAuth Determines if user is authenticated
- *  @param {array} groupsActivity Data for active groups
- *  @param {string} groupRequested The name of the group being requested to join
+ *  @param {array} groups Data for groups
  *  @param {function} onJoinGroup Handles a join request
  */
-const GroupSummary = ({isAuth, groupsActivity, groupRequested, onJoinGroup}) => (
-  <GroupsRecent
-    isAuth={isAuth}
-    groupsActivity={groupsActivity}
-    groupRequested={groupRequested}
-    onJoinGroup={onJoinGroup}
-  />
-)
+const GroupSummary = ({isAuth, groupRequested, onJoinGroup, groups}) => {
+  if (groups.groupsActivity.length) {
+    return (
+      <Grid columns={1} stackable>
+        <Grid.Column>
+          <GroupsCreated
+            groupsCreated={groups.groupsCreated}
+          />
+          <GroupsRecent
+            isAuth={isAuth}
+            groupsActivity={groups.groupsActivity}
+            groupRequested={groupRequested}
+            onJoinGroup={onJoinGroup}
+          />
+        </Grid.Column>
+      </Grid>
+    )
+  }else {
+    return (
+      <Segment>
+        No communities.
+      </Segment>
+    )
+  }
+}
 
 export default GroupSummary;

--- a/client/src/components/pages/Groups/Groups.css
+++ b/client/src/components/pages/Groups/Groups.css
@@ -1,7 +1,13 @@
-#GroupPage .ui.label.head {
+
+
+#GroupPageRecent .ui.label.head {
   line-height: 1.3rem
 }
 
-#GroupPage .ui.label.head .right {
+#GroupPageRecent .ui.label.head .right {
   font-size: 1rem
+}
+
+.ui.label.adjMarginBot {
+  margin-bottom: 1em;
 }

--- a/client/src/components/pages/Groups/Groups.js
+++ b/client/src/components/pages/Groups/Groups.js
@@ -18,7 +18,7 @@ import './Groups.css';
 class Groups extends Component {
   state = {
     areGroupsLoading: true,
-    groupsActivity: [],
+    groups: {},
     groupRequested: '',
     go: true,
   }
@@ -52,13 +52,12 @@ class Groups extends Component {
    *  @param {string} user User logged in
    */
   getGroups = (user) => {
-    const listLimit = 20;
-    getGroupsPage(user, listLimit)
+    getGroupsPage(user)
     .then(result => {
-      if (result) {
+      if (result.data) {
         this.setState({
           areGroupsLoading: false,
-          groupsActivity: result.data.groupsActivity,
+          groups: result.data,
           go: false
         });
       } else {
@@ -96,10 +95,16 @@ class Groups extends Component {
     const {user, csrf} = this.props;
     requestToJoinGroup({group, user}, csrf)
     .then(result => {
-      const {groupsActivity, groupRequested}= this.state;
-      let gActivity = groupsActivity;
+
+      const {
+        groups,
+        groupRequested
+      } = this.state;
+
+      let gActivity = groups.groupsActivity;
+
       if (result.data) {
-        const newGroup = groupsActivity.map(g => {
+        const newGroup = gActivity.map(g => {
           if (g.name === groupRequested) {
             return {
               ...g,
@@ -113,7 +118,10 @@ class Groups extends Component {
         gActivity = newGroup;
       }
       this.setState({
-        groupsActivity: gActivity,
+        groups: {
+          ...groups,
+          groupsActivity: gActivity,
+        },
         groupRequested: '',
       });
 
@@ -127,8 +135,8 @@ class Groups extends Component {
     const {
       state: {
         areGroupsLoading,
-        groupsActivity,
         groupRequested,
+        groups,
       },
       props: {
         isAuth,
@@ -141,9 +149,9 @@ class Groups extends Component {
       : (
         <GroupSummary
           isAuth={isAuth}
-          groupsActivity={groupsActivity}
           groupRequested={groupRequested}
           onJoinGroup={this.onJoinGroup}
+          groups={groups}
         />
       )
     )

--- a/client/src/components/pages/Groups/Groups.js
+++ b/client/src/components/pages/Groups/Groups.js
@@ -2,36 +2,43 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Loader } from "semantic-ui-react";
 
-//import PropTypes from 'prop-types';
-//import moment from 'moment';
+import PropTypes from 'prop-types';
 
 import { getGroupsPage, requestToJoinGroup, logger } from '../../../utils/fetchFunctions';
 import GroupSummary from './GroupSummary';
 import './Groups.css';
 
-//Show list of recent communities added. Option to sort by:
-// New, Popular (Likes), Activity (Recent submissions), Rating
-//
+//TODO: Show list of recent communities added. Option to sort by:
+//New, Popular (Likes), Activity (Recent submissions), Rating
+
+/**
+ *  Community page component that displays a variety of data tailored around
+ *  the community activity. From recently active, to popular, to newly created.
+ */
 class Groups extends Component {
   state = {
-    /*groups: {
-      list,
-      activity,
-    }
-    */
-    //groupsList: [],
     areGroupsLoading: true,
     groupsActivity: [],
     groupRequested: '',
     go: true,
   }
 
+  /**
+   *  When going to Communities page from other pages, load componentDidMount
+   *  with props set and fetch data.
+   */
   componentDidMount() {
-    //this.setState({areGroupsLoading: true});
     const {user} = this.props;
     if (user) this.getGroups(user);
   }
 
+  /**
+   *  When Comommunities page is the first page, props aren't set yet, check
+   *  props for user set and then fetch data. `go` is a flad to run only once
+   *  on update check (else infinite loop)
+   *
+   *  @param {object} prevProps Previous props
+   */
   componentDidUpdate(prevProps) {
     const {user} = this.props;
     if (user && this.state.go) {
@@ -39,13 +46,17 @@ class Groups extends Component {
     }
   }
 
+  /**
+   *  Get the various community data to display on the page.
+   *
+   *  @param {string} user User logged in
+   */
   getGroups = (user) => {
     const listLimit = 20;
     getGroupsPage(user, listLimit)
     .then(result => {
       if (result) {
         this.setState({
-          //groupsList: result.groupsList,
           areGroupsLoading: false,
           groupsActivity: result.data.groupsActivity,
           go: false
@@ -61,6 +72,13 @@ class Groups extends Component {
     });
   }
 
+  /**
+   *  When user requests to join a community, send the request to DB
+   *  for processing.
+   *
+   *  @param {element} e Element onClick comes from
+   *  @param {string} group Group being requested to join
+   */
   onJoinGroup = (e, group) => {
     e.preventDefault();
     this.setState({
@@ -69,13 +87,18 @@ class Groups extends Component {
     this.joinGroupRequest(group);
   }
 
+  /**
+   *  Send request to DB, return true to remove `Join` for group.
+   *
+   *  @param {string} group Group being requested to join
+   */
   joinGroupRequest = (group) => {
     const {user, csrf} = this.props;
     requestToJoinGroup({group, user}, csrf)
     .then(result => {
-      //let gActivity = groupsActivity;
+      const {groupsActivity, groupRequested}= this.state;
+      let gActivity = groupsActivity;
       if (result.data) {
-        const {groupsActivity, groupRequested}= this.state;
         const newGroup = groupsActivity.map(g => {
           if (g.name === groupRequested) {
             return {
@@ -87,22 +110,13 @@ class Groups extends Component {
           }
           return g;
         });
-        //gActivity = newGroup;
-        this.setState({
-          groupsActivity: newGroup,
-          groupRequested: '',
-        });
-      }else {
-        this.setState({
-          groupRequested: '',
-        });
+        gActivity = newGroup;
       }
-      /*
       this.setState({
         groupsActivity: gActivity,
         groupRequested: '',
       });
-      */
+
     }).catch(err => {
       logger('error', err);
     });
@@ -112,11 +126,9 @@ class Groups extends Component {
 
     const {
       state: {
-        //groupsList,
         areGroupsLoading,
         groupsActivity,
         groupRequested,
-        //groupRequested
       },
       props: {
         isAuth,

--- a/client/src/components/pages/Groups/GroupsCreated.js
+++ b/client/src/components/pages/Groups/GroupsCreated.js
@@ -3,6 +3,11 @@ import { Header, Table, Label } from "semantic-ui-react";
 import { Link } from 'react-router-dom';
 import moment from 'moment';
 
+/**
+ *  Show the newly created groups as a table list.
+ *
+ *  @param {array} groupsCreated Data for newly created groups
+ */
 const GroupsCreated = ({ groupsCreated }) => {
   return (
 

--- a/client/src/components/pages/Groups/GroupsCreated.js
+++ b/client/src/components/pages/Groups/GroupsCreated.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Header, Table, Label } from "semantic-ui-react";
+import { Link } from 'react-router-dom';
+import moment from 'moment';
+
+const GroupsCreated = ({ groupsCreated }) => {
+  return (
+
+    <React.Fragment>
+      <Label size='large' color='blue'><Header>Newly Created</Header></Label>
+
+      <Table striped>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Group</Table.HeaderCell>
+            <Table.HeaderCell textAlign='center'>Posts</Table.HeaderCell>
+            <Table.HeaderCell textAlign='center'>Users</Table.HeaderCell>
+            <Table.HeaderCell textAlign='center'>Created</Table.HeaderCell>
+            <Table.HeaderCell textAlign='center'>Owner</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {
+            groupsCreated.map((g, i) => {
+              return (
+                <Table.Row key={g._id}>
+                  <Table.Cell>{g.display}</Table.Cell>
+                  <Table.Cell collapsing textAlign='center'>{g.posts}</Table.Cell>
+                  <Table.Cell collapsing textAlign='center'>{g.users}</Table.Cell>
+                  <Table.Cell collapsing textAlign='center'>{moment.utc(g.created).fromNow()}</Table.Cell>
+                  <Table.Cell collapsing textAlign='center'>{g.owner}</Table.Cell>
+                </Table.Row>
+              )
+            })
+          }
+        </Table.Body>
+      </Table>
+    </React.Fragment>
+  )
+}
+
+export default GroupsCreated;

--- a/client/src/components/pages/Groups/GroupsRecent.js
+++ b/client/src/components/pages/Groups/GroupsRecent.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Loader, Dimmer, Grid, Header, Segment, Label } from "semantic-ui-react";
 import { Link } from 'react-router-dom';
 
@@ -15,71 +15,67 @@ import { Link } from 'react-router-dom';
 const GroupsRecent = ({ isAuth, groupsActivity, groupRequested, onJoinGroup }) => {
   if (groupsActivity.length) {
     return (
-
-      <Grid columns={1} stackable id='GroupPage'>
-        {
-          groupsActivity.map((g,i) => (
-            <Grid.Column key={i} width={8}>
-              <Segment.Group className='box'>
-                <Segment>
-                  <Label attached='top' className='head'>
-                    <div className='left'>
-                      <Header as='h3'>
-                        {g.display}
-                      </Header>
-                    </div>
-                    <div className='right'>
+      <React.Fragment>
+        <Label size='large' color='blue' className='adjMarginBot'><Header>Recently Active</Header></Label>
+        <Grid columns={1} stackable id='GroupPageRecent'>
+          {
+            groupsActivity.map((g,i) => (
+              <Grid.Column key={i} width={8}>
+                <Segment.Group className='box'>
+                  <Segment>
+                    <Label attached='top' className='head'>
+                      <div className='left'>
+                        <Header as='h3'>
+                          {g.display}
+                        </Header>
+                      </div>
+                      <div className='right'>
+                        {
+                          (isAuth)
+                          ? (groupRequested === g.name)
+                            ? <Dimmer inverted active><Loader /></Dimmer>
+                            : (g.access && g.access.access !== 100)
+                              ? ''
+                              : (g.access && g.access.access === 100)
+                                ? 'Requested'
+                                : (
+                                  <a
+                                    href={`/join/${g.name}`}
+                                    onClick={e => onJoinGroup(e, g.name)}
+                                  >
+                                    {'Join'}
+                                  </a>
+                                )
+                          : 'Login to Join'
+                        }
+                      </div>
+                      <div className='clear' />
+                    </Label>
+                    <ul className='custom-list'>
                       {
-                        (isAuth)
-                        ? (groupRequested === g.name)
-                          ? <Dimmer inverted active><Loader /></Dimmer>
-                          : (g.access && g.access.access !== 100)
-                            ? ''
-                            : (g.access && g.access.access === 100)
-                              ? 'Requested'
-                              : (
-                                <a
-                                  href={`/join/${g.name}`}
-                                  onClick={e => onJoinGroup(e, g.name)}
-                                >
-                                  {'Join'}
-                                </a>
-                              )
-                        : 'Login to Join'
+                        g.posts.length
+                        ? g.posts.map(p => (
+                          <li key={p._id}>
+                            <Link
+                              to={p.st_category+'/@'+p.st_author+'/'+p.st_permlink}
+                            >
+                              {`\u2022\u00A0`}
+                              {(p.st_title.length > 40)
+                                ? p.st_title.substr(0,40) + " ..."
+                                : p.st_title}
+                            </Link>
+                          </li>
+                        )) : 'No posts.'
                       }
-                    </div>
-                    <div className='clear' />
-                  </Label>
-                  <ul className='custom-list'>
-                    {
-                      g.length
-                      ? g.posts.map(p => (
-                        <li key={p._id}>
-                          <Link
-                            to={p.st_category+'/@'+p.st_author+'/'+p.st_permlink}
-                          >
-                            {`\u2022\u00A0`}
-                            {(p.st_title.length > 40)
-                              ? p.st_title.substr(0,40) + " ..."
-                              : p.st_title}
-                          </Link>
-                        </li>
-                      )) : 'No posts.'
-                    }
-                  </ul>
-                </Segment>
-              </Segment.Group>
-            </Grid.Column>
-          ))
-        }
-      </Grid>
+                    </ul>
+                  </Segment>
+                </Segment.Group>
+              </Grid.Column>
+            ))
+          }
+        </Grid>
+      </React.Fragment>
     );
-  }else {
-    return (
-      <div>
-        No communities.
-      </div>
-    )
   }
 }
 

--- a/client/src/components/pages/Groups/GroupsRecent.js
+++ b/client/src/components/pages/Groups/GroupsRecent.js
@@ -2,96 +2,85 @@ import React, { Component } from 'react';
 import { Loader, Dimmer, Grid, Header, Segment, Label } from "semantic-ui-react";
 import { Link } from 'react-router-dom';
 
-class GroupsRecent extends Component {
-  state = {
-    //reqJoinSent: false,
-    //groupRequested: '',
-  }
+/**
+ *  Show the most recently active communities. Allow logged in users todo
+ *  request to join a community with the `Join` link. Once clicked, user sees
+ *  `Requested` which remains until request is approved or rejected.
+ *
+ *  @param {boolean} isAuth Determines if user is authenticated
+ *  @param {array} groupsActivity Data for active groups
+ *  @param {string} groupRequested The name of the group being requested to join
+ *  @param {function} onJoinGroup Handles a join request
+ */
+const GroupsRecent = ({ isAuth, groupsActivity, groupRequested, onJoinGroup }) => {
+  if (groupsActivity.length) {
+    return (
 
-  render() {
-
-    const {
-      /*state: {
-        //reqJoinSent,
-      },*/
-      props: {
-        isAuth,
-        groupsActivity,
-        groupRequested,
-        onJoinGroup
-      }
-    } = this;
-
-    if (groupsActivity.length) {
-      return (
-
-        <Grid columns={1} stackable id='GroupPage'>
-          {
-            groupsActivity.map((g,i) => (
-              <Grid.Column key={i} width={8}>
-                <Segment.Group className='box'>
-                  <Segment>
-                    <Label attached='top' className='head'>
-                      <div className='left'>
-                        <Header as='h3'>
-                          {g.display}
-                        </Header>
-                      </div>
-                      <div className='right'>
-                        {
-                          (isAuth)
-                          ? (groupRequested === g.name)
-                            ? <Dimmer inverted active><Loader /></Dimmer>
-                            : (g.access && g.access.access !== 100)
-                              ? ''
-                              : (g.access && g.access.access === 100)
-                                ? 'Requested'
-                                : (
-                                  <a
-                                    href={`/join/${g.name}`}
-                                    onClick={e => onJoinGroup(e, g.name)}
-                                  >
-                                    {'Join'}
-                                  </a>
-                                )
-                          : 'Login to Join'
-                        }
-                      </div>
-                      <div className='clear' />
-                    </Label>
-                    <ul className='custom-list'>
+      <Grid columns={1} stackable id='GroupPage'>
+        {
+          groupsActivity.map((g,i) => (
+            <Grid.Column key={i} width={8}>
+              <Segment.Group className='box'>
+                <Segment>
+                  <Label attached='top' className='head'>
+                    <div className='left'>
+                      <Header as='h3'>
+                        {g.display}
+                      </Header>
+                    </div>
+                    <div className='right'>
                       {
-                        g.length
-                        ? g.posts.map(p => (
-                          <li key={p._id}>
-                            <Link
-                              to={p.st_category+'/@'+p.st_author+'/'+p.st_permlink}
-                            >
-                              {`\u2022\u00A0`}
-                              {(p.st_title.length > 40)
-                                ? p.st_title.substr(0,40) + " ..."
-                                : p.st_title}
-                            </Link>
-                          </li>
-                        )) : 'No posts.'
+                        (isAuth)
+                        ? (groupRequested === g.name)
+                          ? <Dimmer inverted active><Loader /></Dimmer>
+                          : (g.access && g.access.access !== 100)
+                            ? ''
+                            : (g.access && g.access.access === 100)
+                              ? 'Requested'
+                              : (
+                                <a
+                                  href={`/join/${g.name}`}
+                                  onClick={e => onJoinGroup(e, g.name)}
+                                >
+                                  {'Join'}
+                                </a>
+                              )
+                        : 'Login to Join'
                       }
-                    </ul>
-                  </Segment>
-                </Segment.Group>
-              </Grid.Column>
-            ))
-          }
-        </Grid>
-      );
-    }else {
-      return (
-        <div>
-          No communities.
-        </div>
-      )
-    }
+                    </div>
+                    <div className='clear' />
+                  </Label>
+                  <ul className='custom-list'>
+                    {
+                      g.length
+                      ? g.posts.map(p => (
+                        <li key={p._id}>
+                          <Link
+                            to={p.st_category+'/@'+p.st_author+'/'+p.st_permlink}
+                          >
+                            {`\u2022\u00A0`}
+                            {(p.st_title.length > 40)
+                              ? p.st_title.substr(0,40) + " ..."
+                              : p.st_title}
+                          </Link>
+                        </li>
+                      )) : 'No posts.'
+                    }
+                  </ul>
+                </Segment>
+              </Segment.Group>
+            </Grid.Column>
+          ))
+        }
+      </Grid>
+    );
+  }else {
+    return (
+      <div>
+        No communities.
+      </div>
+    )
   }
-
 }
 
 export default GroupsRecent;

--- a/client/src/components/pages/Home/Home.js
+++ b/client/src/components/pages/Home/Home.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import moment from 'moment';
 import { Link } from 'react-router-dom';
 
-import { fetchRecentIfNeeded } from '../../../actions/recentPostsActions';
+import { fetchPosts } from '../../../actions/recentPostsActions';
 import RecentPosts from './RecentPosts'
 import './Home.css';
 
@@ -41,7 +41,7 @@ class Home extends Component {
   componentDidMount() {
     const {selected, dispatch, user} = this.props;
     if (user !== '') {
-      dispatch(fetchRecentIfNeeded(selected, user));
+      dispatch(fetchPosts(selected, user));
     }
   }
 
@@ -49,7 +49,7 @@ class Home extends Component {
   componentDidUpdate(prevProps) {
     const {selected, dispatch, user} = this.props;
     if (prevProps.user !== user) {
-      dispatch(fetchRecentIfNeeded(selected, user));
+      dispatch(fetchPosts(selected, user));
     }
   }
 

--- a/client/src/components/pages/Home/Home.js
+++ b/client/src/components/pages/Home/Home.js
@@ -118,7 +118,7 @@ class Home extends Component {
                           </Label>
                           <ul className='custom-list'>
                             {
-                              g.length
+                              g.posts.length
                               ? g.posts.map(p => (
                                 <li key={p._id}>
                                   <Link

--- a/client/src/components/pages/Kurate/Kurate.js
+++ b/client/src/components/pages/Kurate/Kurate.js
@@ -22,6 +22,8 @@ class Kurate extends Component {
 
   static propTypes = {
     user: PropTypes.string,
+    csrf: PropTypes.string,
+    match: PropTypes.arrayOf(PropTypes.object),
   };
 
   constructor(props) {
@@ -209,7 +211,9 @@ class Kurate extends Component {
     });
   }
 
-
+  /**
+   *  Change the style to show posts when data is returned.
+   */
   onPostsGet = () => {
     this.setState({postsListShow: 'block'})
   }
@@ -239,15 +243,6 @@ class Kurate extends Component {
      });
   }
 
-  /*onClickTitle = (e, url) => {
-    e.preventDefault();
-console.log('h:',this.props.history)
-    //this.context.history.push('/url');
-    //this.props.router.push(url)
-    this.props.history.push(url)
-  }*/
-
-
   render() {
     const {
       state: {
@@ -259,7 +254,6 @@ console.log('h:',this.props.history)
         postExists,
         addPostLoading,
         tag,
-        //selectedFilter,
       },
       props: {
         user,

--- a/client/src/components/pages/Kurate/Kurate.js
+++ b/client/src/components/pages/Kurate/Kurate.js
@@ -23,7 +23,12 @@ class Kurate extends Component {
   static propTypes = {
     user: PropTypes.string,
     csrf: PropTypes.string,
-    match: PropTypes.arrayOf(PropTypes.object),
+    match: PropTypes.shape(PropTypes.object.isRequired).isRequired,
+  };
+
+  static defaultProps = {
+    user: '',
+    csrf: '',
   };
 
   constructor(props) {

--- a/client/src/components/pages/Kurate/PostDetails.js
+++ b/client/src/components/pages/Kurate/PostDetails.js
@@ -1,36 +1,38 @@
 import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 import Remarkable from 'remarkable';
 import { Client } from 'dsteem';
 import { Grid } from "semantic-ui-react";
 import moment from 'moment';
 
-//import HtmlReady from '../pages/Kurate/helpers/htmlready';
-//import { extractContent } from '../pages/Kurate/helpers/formatters';
 import RepLog10 from '../../../utils/reputationCalc';
 import AuthorCatgoryTime from './AuthorCatgoryTime';
 import PostActions from './PostActions';
 import replaceLinks from './helpers/replaceLinks';
 
-/*import { getUserGroups, addPost, logger } from '../../../utils/fetchFunctions';
-import ModalGroup from '../Modal/ModalGroup';
-import ErrorLabel from '../ErrorLabel/ErrorLabel';*/
-
 import './PostDetails.css'
 
 const client = new Client('https://hive.anyx.io/');
 
+/**
+ *  Renders the post details for Steem content for a user to view.
+ */
 class PostDetails extends Component {
+  static propTypes = {
+    match: PropTypes.arrayOf(PropTypes.object).isRequired,
+    showModal: PropTypes.func.isRequired,
+    user: PropTypes.string.isRequired,
+  };
+
   state = {
     post: {},
     isLoading: true,
-    /*modalOpenAddPost: false,
-    addPostData: {},
-    postExists: false,
-    addPostLoading: false,*/
   }
 
+  /**
+   *  Fetch post detail from Steem blockchain on component mount.
+   */
   componentDidMount() {
-//console.log('pp:',this.props)
     const {
       match: {
         params: {
@@ -43,10 +45,17 @@ class PostDetails extends Component {
     this.openPost(author, permlink);
   }
 
+  //Needed to `dangerouslySetInnerHTML`
   createMarkup = (html) => {
     return {__html: html};
   }
 
+  /**
+   *  Open the post for user to see.
+   *
+   *  @param {string} author Author of content
+   *  @param {string} permlink Permlink of content
+   */
   openPost = (author, permlink) => {
     client.database.call('get_content', [author, permlink]).then(result => {
       this.setState({

--- a/client/src/components/pages/Kurate/PostDetails.js
+++ b/client/src/components/pages/Kurate/PostDetails.js
@@ -19,7 +19,7 @@ const client = new Client('https://hive.anyx.io/');
  */
 class PostDetails extends Component {
   static propTypes = {
-    match: PropTypes.arrayOf(PropTypes.object).isRequired,
+    match: PropTypes.shape(PropTypes.object.isRequired).isRequired,
     showModal: PropTypes.func.isRequired,
     user: PropTypes.string.isRequired,
   };

--- a/client/src/components/pages/Kurate/helpers/formatters.js
+++ b/client/src/components/pages/Kurate/helpers/formatters.js
@@ -1,7 +1,5 @@
 /**
  * Based on ExtractContent.js from Steem condenser front-end by Steemit Inc. @ https://github.com/steemit/condenser/blob/master/src/app/utils/ExtractContent.js
- *
- *
  */
 
 import Remarkable from 'remarkable';

--- a/client/src/components/pages/Kurate/helpers/htmlready.js
+++ b/client/src/components/pages/Kurate/helpers/htmlready.js
@@ -1,3 +1,8 @@
+/**
+ *  Grabbed from Steemit's condenser:
+ *  https://github.com/steemit/condenser/blob/master/src/shared/HtmlReady.js
+ */
+
 import xmldom from 'xmldom';
 //import linksRe, { any as linksAny } from './links';
 

--- a/client/src/components/pages/Kurate/helpers/remarkablestripper.js
+++ b/client/src/components/pages/Kurate/helpers/remarkablestripper.js
@@ -1,3 +1,8 @@
+/**
+ *  Grabbed from Steemit's condenser
+ *  https://github.com/steemit/condenser/blob/master/src/app/utils/RemarkableStripper.js
+ */
+
 import Remarkable from 'remarkable';
 
 const remarkable = new Remarkable();

--- a/client/src/components/pages/Kurate/helpers/replaceLinks.js
+++ b/client/src/components/pages/Kurate/helpers/replaceLinks.js
@@ -1,4 +1,7 @@
-
+/**
+ *  Grabbed from Steemit's condenser:
+ *  https://github.com/steemit/condenser/blob/master/src/shared/HtmlReady.js
+ */
 
 const urlChar = '[^\\s"<>\\]\\[\\(\\)]';
 const urlCharEnd = urlChar.replace(/\]$/, ".,']"); // insert bad chars to end on
@@ -6,7 +9,6 @@ const imagePath =
     '(?<!img.*>)(?:(?:\\.(?:tiff?|jpe?g|gif|png|svg|ico)|ipfs/[a-z\\d]{40,}))';
 const domainPath = '(?:[-a-zA-Z0-9\\._]*[-a-zA-Z0-9])';
 const urlChars = '(?:' + urlChar + '*' + urlCharEnd + ')?';
-
 const urlSet = ({ domain = domainPath, path } = {}) => {
     // urlChars is everything but html or markdown stop chars
     //eslint-disable-next-line
@@ -20,6 +22,11 @@ const urlSet = ({ domain = domainPath, path } = {}) => {
     //https://localhost:3000/news/@rebe.torres12/una-renegada-a-renegade
 };
 
+/**
+ *  Replace http image links with real <img> html tags.
+ *
+ *  @param {string} body Content to scan.
+ */
 const replaceLinks = (body) => {
   return body = body.replace(new RegExp(urlSet(), 'gi'), ln => {
 

--- a/client/src/components/pages/Manage/GroupManage.js
+++ b/client/src/components/pages/Manage/GroupManage.js
@@ -371,6 +371,12 @@ class GroupManage extends Component {
     })
   }
 
+  /**
+   *  Call databse function for approve/deny of user join request.
+   *
+   *  @param {string} newUser User name to approve
+   *  @param {string} type Type of approval action (approve/deny)
+   */
   handleApproval = (e, newUser, type) => {
     e.preventDefault();
     const {group} = this.state;
@@ -379,6 +385,14 @@ class GroupManage extends Component {
     else if (type === 'deny') this.denyUserFetch(group, newUser);
   }
 
+  /**
+   *  New user to be approved to a community group.
+   *  Update the state with user list appended, and remove pending user.
+   *  Clear the `approvingUser` string to remove loader.
+   *
+   *  @param {string} group Group name to approve for
+   *  @param {string} newUser User name to aprove
+   */
   approveUserFetch = (group, newUser) => {
     approveUser({group, newUser, user: this.user}, this.csrf)
     .then(res => {
@@ -389,8 +403,8 @@ class GroupManage extends Component {
           this.setState({
             pending: newPending,
             users: [
-              ...users,
               res.data.newUser,
+              ...users,
             ],
             approvingUser: '',
           });
@@ -405,6 +419,14 @@ class GroupManage extends Component {
     });
   }
 
+  /**
+   *  New user to be denied joining a community group.
+   *  Update the state newUser removed from pending user list.
+   *  Clear the `approvingUser` string to remove loader.
+   *
+   *  @param {string} group Group name to deny for
+   *  @param {string} newUser User name to deny
+   */
   denyUserFetch = (group, newUser) => {
     denyUser({group, newUser, user: this.user}, this.csrf)
     .then(res => {

--- a/client/src/components/pages/Manage/GroupManage.js
+++ b/client/src/components/pages/Manage/GroupManage.js
@@ -271,6 +271,7 @@ class GroupManage extends Component {
    *  Trim user name, validate it's structure, set loading flag.
    */
   handleSubmitNewUser = () => {
+
     let { newUser, selectedAccess } = this.state;
     newUser = newUser.trim();
 
@@ -321,6 +322,8 @@ class GroupManage extends Component {
             ],
             newUser: '',
           });
+          const { onUserUpdate } = this.props;
+          onUserUpdate(group, 'inc');
         }
         this.setState({
           addUserLoading: false,
@@ -365,6 +368,8 @@ class GroupManage extends Component {
           deletingUser: '',
           users: newUsers
         });
+        const { onUserUpdate } = this.props;
+        onUserUpdate(group, 'dec');
       }/*else error deleting user*/
     }).catch(err => {
       throw new Error('Error deleting user: ', err);
@@ -408,6 +413,8 @@ class GroupManage extends Component {
             ],
             approvingUser: '',
           });
+          const { onUserUpdate } = this.props;
+          onUserUpdate(group, 'inc');
         }else {
           this.setState({
             approvingUser: '',

--- a/client/src/components/pages/Manage/GroupManagePending.js
+++ b/client/src/components/pages/Manage/GroupManagePending.js
@@ -18,7 +18,9 @@ import moment from 'moment';
 const GroupManagePending = ({pending, handleApproval, approvingUser}) => (
   <React.Fragment>
     <div className='clear' />
-    <Header className='noMarginTop'>Join Requests</Header>
+    <Header className='noMarginTop'>
+      {`Join Requests (${pending.length})`}
+    </Header>
     <div>
       {
         (pending.length)
@@ -52,7 +54,6 @@ const GroupManagePending = ({pending, handleApproval, approvingUser}) => (
                       <a href={`/approve/${u.user}/`} onClick={e => handleApproval(e, u.user, 'approve')}><Icon name='plus' color='blue' /></a>
                       {' / '}
                       <a href={`/deny/${u.user}/`} onClick={e => handleApproval(e, u.user, 'deny')}><Icon name='delete' color='blue' /></a>
-
                     </Table.Cell>
                   </Table.Row>
                   )

--- a/client/src/components/pages/Manage/GroupManagePending.js
+++ b/client/src/components/pages/Manage/GroupManagePending.js
@@ -1,9 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Grid, Table, Icon, Dimmer, Loader, Header, Segment } from "semantic-ui-react";
+import { Table, Icon, Dimmer, Loader, Header, Segment } from "semantic-ui-react";
 import { Link } from 'react-router-dom';
 import moment from 'moment';
 
+/**
+ *  Table of user pending approval for community group.
+ *
+ *  Shows the user name, when they requested to join, and a button icon for
+ *  approval or denial of request to join.
+ *
+ *  @param {array} props.pending Data for user's pending approval for group
+ *  @param {function} props.handleApproval Handles approve/deny action
+ *  @param {string} props.approvingUser User being approved
+ *  @returns {Component} Table of user data
+ */
 const GroupManagePending = ({pending, handleApproval, approvingUser}) => (
   <React.Fragment>
     <div className='clear' />
@@ -55,5 +66,11 @@ const GroupManagePending = ({pending, handleApproval, approvingUser}) => (
     </div>
   </React.Fragment>
 )
+
+GroupManagePending.propTypes = {
+  pending: PropTypes.arrayOf(PropTypes.object).isRequired,
+  handleApproval: PropTypes.func.isRequired,
+  approvingUser: PropTypes.string.isRequired,
+};
 
 export default GroupManagePending;

--- a/client/src/components/pages/Manage/GroupManageUsers.js
+++ b/client/src/components/pages/Manage/GroupManageUsers.js
@@ -17,6 +17,9 @@ import {roles} from '../../../settings';
  *  @param {function} props.showModal Sets the modal to be shown or hidden
  *  @param {string} props.deletingUser The user to be deleted
  *  @param {string} props.access Access type for user logged in
+ *  @param {array} props.pending Data for user's pending approval for group
+ *  @param {function} props.handleApproval Handles approve/deny action
+ *  @param {string} props.approvingUser User being approved
  *  @returns {Component} Table of user data
  */
 const GroupManageUsers = ({users, showModal, deletingUser, access, pending, handleApproval, approvingUser}) => (
@@ -91,6 +94,9 @@ GroupManageUsers.propTypes = {
   showModal: PropTypes.func.isRequired,
   deletingUser: PropTypes.string.isRequired,
   access: PropTypes.number.isRequired,
+  pending: PropTypes.arrayOf(PropTypes.object).isRequired,
+  handleApproval: PropTypes.func.isRequired,
+  approvingUser: PropTypes.string.isRequired,
 };
 
 export default GroupManageUsers;

--- a/client/src/components/pages/Manage/GroupManageUsers.js
+++ b/client/src/components/pages/Manage/GroupManageUsers.js
@@ -32,7 +32,9 @@ const GroupManageUsers = ({users, showModal, deletingUser, access, pending, hand
     />
 
     <div className='clear' />
-    <Header>Membership</Header>
+    <Header>
+      {`Members (${users.length})`}
+    </Header>
 
     <Table striped>
       <Table.Header>

--- a/client/src/components/pages/Manage/GroupsList.js
+++ b/client/src/components/pages/Manage/GroupsList.js
@@ -93,6 +93,14 @@ const GroupsList = (props) => {
                         {'Posts: '}
                         {g.posts}
                       </div>
+                      <div>
+                        {'Users: '}
+                        {g.users}
+                      </div>
+                      <div>
+                        {'Join Requests: '}
+                        {g.joinRequests}
+                      </div>
                       {/*<div>Followers: {g.followers}</div>*/}
                       {/*<div>Likes: {g.likes}</div>*/}
                     </div>

--- a/client/src/components/pages/Manage/ManageGroups.js
+++ b/client/src/components/pages/Manage/ManageGroups.js
@@ -303,6 +303,26 @@ class ManageGroups extends Component {
     this.setState({groups: newGroups});
   }
 
+  /**
+   *  Increment or decrement the user value for group.
+   *
+   *  @param {string} groupToUpdate Group name to update
+   *  @param {string} action Increment or decrement post quantity
+   */
+  onUserUpdate = (groupToUpdate, action) => {
+    const { groups } = this.state;
+    const newGroups = groups.map(g => {
+      if (groupToUpdate === g.name) {
+        g = {
+          ...g,
+          users: g.users+(action === 'inc' ? 1 : -1)
+        };
+      }
+      return g;
+    });
+    this.setState({groups: newGroups});
+  }
+
   render() {
     const {
       newGroup,
@@ -342,16 +362,9 @@ class ManageGroups extends Component {
       <React.Fragment>
         <Grid.Row className="header-row">
           <Grid.Column floated='left' width={10}>
-
-            <Label size='big' color='blue'><Header as="h2">{headerText}</Header></Label>
-            {
-                /*<SearchComponent
-                onResultSelect={this.handleResultSelect}
-                onSearchChange={this.handleSearchChange}
-                results={searchResults}
-                value={searchValue}
-              />*/
-          }
+            <Label size='big' color='blue'>
+              <Header as="h2">{headerText}</Header>
+            </Label>
           </Grid.Column>
           {type === 'owned' &&
             (
@@ -408,6 +421,7 @@ class ManageGroups extends Component {
               csrf={csrf}
               user={user}
               onPostUpdate={this.onPostUpdate}
+              onUserUpdate={this.onUserUpdate}
             />
           )
         }

--- a/client/src/utils/fetchFunctions.js
+++ b/client/src/utils/fetchFunctions.js
@@ -1,9 +1,9 @@
 import axios from 'axios';
 
 /**
- *  Get the groups a user is assocaited with.
+ *  Get the community a user is assocaited with.
  *
- *  @param {string} user User to get groups for
+ *  @param {string} user User to get community for
  *  @param {string} type Type of group, 'owned', 'joined' or 'all'
  */
 export const getUserGroups = (user, type) => {
@@ -11,9 +11,9 @@ export const getUserGroups = (user, type) => {
 }
 
 /**
- *  Get the group to manage.
+ *  Get the community to manage.
  *
- *  @param {string} group Requested group
+ *  @param {string} group Requested community
  *  @param {string} user User to get groups for
  */
 export const getManageGroup = (group, user) => {
@@ -22,7 +22,7 @@ export const getManageGroup = (group, user) => {
 
 /**
  *  Get the recent posts and community activity on the site, and the
- *  recent group activity and submittions a user is assocaited with.
+ *  recent community activity and submittions a user is assocaited with.
  *
  *  @param {string} user User to get groups for
  *  @param {string} limit Limit of records to return
@@ -50,7 +50,7 @@ const getData = (path) => {
 }
 
 /**
- *  Call/fetch to add a group.
+ *  Call/fetch to add a community.
  *
  *  @param {object} params Data to pass to server fetch
  *  @param {string} csrf CSRF token
@@ -60,7 +60,7 @@ export const addGroup = (params, csrf) => {
 }
 
 /**
- *  Call/fetch to delete a group.
+ *  Call/fetch to delete a community.
  *
  *  @param {object} params Data to pass to server fetch
  *  @param {string} csrf CSRF token
@@ -109,14 +109,32 @@ export const deleteUser = (params, csrf) => {
   return postData('/manage/users/delete', params, csrf);
 }
 
+/**
+ *  Call/fetch to request joining a community.
+ *
+ *  @param {object} params Data to pass to server fetch
+ *  @param {string} csrf CSRF token
+ */
 export const requestToJoinGroup = (params, csrf) => {
   return postData('/manage/groups/join', params, csrf);
 }
 
+/**
+ *  Call/fetch to approve a user's request to join a community.
+ *
+ *  @param {object} params Data to pass to server fetch
+ *  @param {string} csrf CSRF token
+ */
 export const approveUser = (params, csrf) => {
   return postData('/manage/users/approve', params, csrf);
 }
 
+/**
+ *  Call/fetch to deny a user's request to join a community.
+ *
+ *  @param {object} params Data to pass to server fetch
+ *  @param {string} csrf CSRF token
+ */
 export const denyUser = (params, csrf) => {
   return postData('/manage/users/deny', params, csrf);
 }

--- a/client/src/utils/fetchFunctions.js
+++ b/client/src/utils/fetchFunctions.js
@@ -36,8 +36,8 @@ export const getRecentActivity = (user, limit = 10) => {
  *
  *  @param {string} limit Limit of records to return
  */
-export const getGroupsPage = (user, listLimit = 20) => {
-  return getData(`/api/groups/list/${listLimit}/${user}`);
+export const getGroupsPage = (user) => {
+  return getData(`/api/groups/list/${user}`);
 }
 
 /**

--- a/server/routes/api/groups.js
+++ b/server/routes/api/groups.js
@@ -141,7 +141,7 @@ router.get('/list/:listlimit/:user', async (req, res, next) => {
       posts: result[2],
       users: result[3]*/
     })
-  })
+  }).catch(next)
 })
 
 /**
@@ -155,11 +155,11 @@ router.get('/:group/:user', async (req, res, next) => {
   const db = req.app.locals.db;
   const { group, user } = req.params;
 
-  const groupName = getGroupDisplayName(db, group);
-  const groupAccess = getGroupAccess(db, group, user)
-  const groupPosts = getGroupPosts(db, group);
-  const groupUsers = getGroupUsers(db, group);
-  const groupPendingUsers = getGroupPendingUsers(db, group);
+  const groupName = getGroupDisplayName(db, next, group);
+  const groupAccess = getGroupAccess(db, next, group, user)
+  const groupPosts = getGroupPosts(db, next, group);
+  const groupUsers = getGroupUsers(db, next, group);
+  const groupPendingUsers = getGroupPendingUsers(db, next, group);
 
   //Resolve promises for group name, group posts and group users
   //Return data to frontend
@@ -184,13 +184,13 @@ router.get('/:group/:user', async (req, res, next) => {
  *  @param {string} group Group to get data from
  *  @returns {object} Group name object to send to frontend
  */
-const getGroupDisplayName = async (db, group) => {
+const getGroupDisplayName = async (db, next, group) => {
   return new Promise((resolve, reject) => {
     db.collection('kgroups').findOne({name: group}, {projection: {display: 1, _id: 0 }}, (err, result) => {
       if (result) resolve(result);
-      else reject(false);
+      else reject(err);
     })
-  })
+  }).catch(next)
 }
 
 /**
@@ -201,13 +201,13 @@ const getGroupDisplayName = async (db, group) => {
  *  @param {string} user User logged in
  *  @returns {object} Group name object to send to frontend
  */
-const getGroupAccess = async (db, group, user) => {
+const getGroupAccess = async (db, next, group, user) => {
   return new Promise((resolve, reject) => {
     db.collection('kgroups_access').findOne({group: group, user: user}, {projection: {access: 1, _id: 0 }}, (err, result) => {
       if (result) resolve(result);
-      else reject();
+      else reject(err);
     })
-  })
+  }).catch(next)
 }
 
 /**
@@ -217,13 +217,13 @@ const getGroupAccess = async (db, group, user) => {
  *  @param {string} group Group to get data from
  *  @returns {object} Group's posts data object to send to frontend
  */
-const getGroupPosts = async (db, group) => {
+const getGroupPosts = async (db, next, group) => {
   return new Promise((resolve, reject) => {
     db.collection('kposts').find({group: group}).sort( { _id: -1 } ).toArray().then(result => {
       if (result) resolve(result);
-      else reject();
+      else reject(false);
     })
-  })
+  }).catch(next)
 }
 
 /**
@@ -233,13 +233,13 @@ const getGroupPosts = async (db, group) => {
  *  @param {string} group Group to get data from
  *  @returns {object} Group's users data object to send to frontend
  */
-const getGroupUsers = async (db, group) => {
+const getGroupUsers = async (db, next, group) => {
   return new Promise((resolve, reject) => {
     db.collection('kgroups_access').find({group: group, access: {$lt: 100}}).sort( { user: 1 } ).toArray().then(result => {
       if (result) resolve(result);
-      else reject();
+      else reject(false);
     })
-  })
+  }).catch(next)
 }
 
 /**
@@ -249,13 +249,13 @@ const getGroupUsers = async (db, group) => {
  *  @param {string} group Group to get data from
  *  @returns {object} Group's users data object to send to frontend
  */
-const getGroupPendingUsers = async (db, group) => {
+const getGroupPendingUsers = async (db, next, group) => {
   return new Promise((resolve, reject) => {
     db.collection('kgroups_access').find({group: group, access: 100}).sort( { user: 1 } ).toArray().then(result => {
       if (result) resolve(result);
-      else reject();
+      else reject(false);
     })
-  })
+  }).catch(next)
 }
 
 

--- a/server/routes/api/groups.js
+++ b/server/routes/api/groups.js
@@ -112,14 +112,15 @@ export const getUserGroups = async (db, next, user, type, limit) => {
  *  Gets the local DB object, group name.
  *  Retrieves the post and user group data for which the user has access.
  */
-router.get('/list/:listlimit/:user', async (req, res, next) => {
+router.get('/list/:user', async (req, res, next) => {
   const db = req.app.locals.db;
-  const { listlimit, user } = req.params;
+  const { user } = req.params;
 
+  const listlimit = 20;
   const groupLimit = 4;
   const postLimit = 5;
 
-  //const groupsCreated = getGroupsCreated(db, next, listLimit);
+  const groupsCreated = getGroupsCreated(db, next, listlimit);
   const groupsActivity = getRecentGroupActivity(db, next, groupLimit, postLimit, user);
 
   /*const groupName = getGroupDisplayName(db, group);
@@ -128,10 +129,11 @@ router.get('/list/:listlimit/:user', async (req, res, next) => {
   const groupUsers = getGroupUsers(db, group);*/
 
   //
-  Promise.all([groupsActivity]).then((result) => {
+  Promise.all([groupsActivity, groupsCreated]).then((result) => {
     res.json({
       //groupsList,
       groupsActivity: result[0],
+      groupsCreated: result[1],
 
       /*group: {
         name: group,
@@ -143,6 +145,15 @@ router.get('/list/:listlimit/:user', async (req, res, next) => {
     })
   }).catch(next)
 })
+
+const getGroupsCreated = (db, next, listLimit) => {
+  return new Promise((resolve, reject) => {
+    db.collection('kgroups').find().sort( { _id: -1 } ).limit(listLimit).toArray().then(result => {
+      if (result) resolve(result);
+      else reject(false);
+    })
+  }).catch(next)
+}
 
 /**
  *  GET route to get posts and users data that belong to a group.

--- a/server/routes/api/recentActivity.js
+++ b/server/routes/api/recentActivity.js
@@ -75,11 +75,13 @@ const getRecentPosts = async (db, next, limit = 50) => {
     ]).toArray((err, result) => {
       err ? reject(err) : resolve(result);
     })
-  })
+  }).catch(next)
 }
 
 /**
- *  Get the Owned or Joined user's groups from DB.
+ *  Get the recent group activity.
+ *  If user logged in, then get a more complex data query of their access
+ *  level to the active groups.
  *
  *  @param {object} db MongoDB connection
  *  @param {function} next Middleware function
@@ -148,16 +150,16 @@ export const getRecentGroupActivity = async (db, next, groupLimit, postLimit, us
         err ? reject(err) : resolve(result);
       })
     }
-  })
+  }).catch(next)
 }
 
 /**
- *  Get the Owned or Joined user's groups from DB.
+ *  Get the recent submissions for curation a user has made.
  *
  *  @param {object} db MongoDB connection
+ *  @param {function} next Middleware function
  *  @param {string} user Logged in user name
  *  @param {number} limit Limit for query return
- *  @param {function} next Middleware function
  *  @returns {object} Recent group activity  data object to send to frontend
  */
 const getMySubmissions = (db, next, user, limit) => {
@@ -165,7 +167,7 @@ const getMySubmissions = (db, next, user, limit) => {
     db.collection('kposts').find({added_by: user}).sort( { _id: -1 } ).limit(limit).toArray((err, result) => {
       err ? reject(err) : resolve(result);
     })
-  })
+  }).catch(next)
 }
 
 export default router;

--- a/server/routes/manage/groups.js
+++ b/server/routes/manage/groups.js
@@ -57,6 +57,7 @@ router.post('/add', async (req, res, next) => {
  *  Query the DB to see if a group already exists.
  *
  *  @param {object} db MongoDB connection
+ *  @param {function} next Express middleware
  *  @param {string} group Group to verify
  *  @returns {boolean} Determines if group exists or not
  */
@@ -76,6 +77,7 @@ const groupExists = async (db, next, group) => {
  *  Query the DB to see if a user has reached their Owned Group limit.
  *
  *  @param {object} db MongoDB connection
+ *  @param {function} next Express middleware
  *  @param {string} user User to verify
  *  @returns {boolean} Determines if a user has reached their limit
  */
@@ -95,6 +97,7 @@ const exceededGrouplimit = async (db, next, user) => {
  *  Insert the new group into the DB.
  *
  *  @param {object} db MongoDB connection
+ *  @param {function} next Express middleware
  *  @param {string} group New group full display name to insert
  *  @param {string} groupTrim New group trimmed name to insert
  *  @param {string} user Logged in user to insert
@@ -179,6 +182,7 @@ router.post('/delete', async (req, res, next) => {
  *  Delete a post from a community group.
  *
  *  @param {object} db MongoDB Connectioon
+ *  @param {function} next Express middleware
  *  @param {string} post Post to remove from the group
  *  @param {string} group Group name to remove from
  *  @returns {boolean} Determines if deleting a post was a success
@@ -242,11 +246,12 @@ router.post('/join', async (req, res, next) => {
 })
 
 /**
- *  Insert the new join request into the DB.
+ *  Insert the new user join request into the DB.
  *
  *  @param {object} db MongoDB connection
- *  @param {string} group New group full display name to insert
- *  @param {string} user Logged in user to insert
+ *  @param {function} next Express middleware
+ *  @param {string} group Group name to requset a join in
+ *  @param {string} user New user to approve
  *  @returns {object} The date the group was created at
  */
 const requestJoinGroup = (db, next, group, user) => {

--- a/server/routes/manage/groups.js
+++ b/server/routes/manage/groups.js
@@ -41,11 +41,14 @@ router.post('/add', async (req, res, next) => {
             name: groupClean,
             display: group,
             owner: user,
-            followers: 1,
-            likes: 1,
+            followers: 0,
+            likes: 0,
             created: created,
             updated: created,
-            posts: 0
+            posts: 0,
+            rating: 0,
+            users: 1,
+            joinRequests: 0
           }
         });
       }
@@ -118,10 +121,12 @@ const groupUpsert = (db, next, group, groupTrim, user) => {
           created: created,
           updated: created,
           owner: user,
-          followers: 1,
-          likes: 1,
+          followers: 0,
+          likes: 0,
           posts: 0,
-          rating: 0
+          rating: 0,
+          users: 1,
+          joinRequests: 0
         }
       },
       { upsert: true }

--- a/server/routes/manage/posts.js
+++ b/server/routes/manage/posts.js
@@ -41,6 +41,7 @@ router.post('/add', async (req, res, next) => {
  *  Query the DB to see if a post already exists.
  *
  *  @param {object} db MongoDB connection
+ *  @param {function} next Middleware function
  *  @param {string} permlink Steem permlink of post
  *  @param {string} group Group to verify if posts exists in
  *  @returns {boolean} Determines if post exists or not
@@ -64,6 +65,7 @@ const postExists = async (db, next, author, permlink, group) => {
  *  to the 'kposts' collection.
  *
  *  @param {object} db MongoDB Connectioon
+ *  @param {function} next Middleware function
  *  @param {string} user User currently logged in
  *  @param {string} group Group name to add to
  *  @param {string} category Category of Steem post
@@ -73,7 +75,6 @@ const postExists = async (db, next, author, permlink, group) => {
  *  @returns {object} Send inserted object back to frontend for use
  */
 const addPost = (db, next, user, group, category, author, permlink, title) => {
-  console.log('1')
   try {
     const created = new Date();
 
@@ -142,6 +143,7 @@ router.post('/delete', async (req, res, next) => {
  *  Delete a post from a community group.
  *
  *  @param {object} db MongoDB Connectioon
+ *  @param {function} next Middleware function
  *  @param {string} post Post to remove from the group
  *  @param {string} group Group name to remove from
  *  @returns {boolean} Determines if deleting a post was a success

--- a/server/routes/manage/users.js
+++ b/server/routes/manage/users.js
@@ -83,11 +83,23 @@ const addUserToGroup = async (db, next, user, newUser, group, access = 3) => {
     }
 
     return new Promise((resolve, reject) => {
-        db.collection('kgroups_access').insertOne(userAccess, (err, res) => {
+
+
+      db.collection('kgroups_access').insertOne(userAccess, (err, res) => {
         if(err) {
           reject('Error addUserToGroup DB: ', err);
         } else {
-         resolve(res.ops[0]);
+
+          db.collection('kgroups').updateOne(
+            { name: group },
+            {
+              $inc:
+              {
+                users: 1
+              }
+            }
+          )
+          resolve(res.ops[0]);
        }
       })
     })
@@ -136,6 +148,16 @@ const deleteUserFromGroup = (db, next, user, group) => {
   try {
     db.collection('kgroups_access').deleteOne(
       { user: user, group: group }
+    )
+
+    db.collection('kgroups').updateOne(
+      { name: group },
+      {
+        $inc:
+        {
+          users: -1
+        }
+      }
     )
     return true;
   }catch (err) {
@@ -221,7 +243,8 @@ const approvalJoinGroup = (db, next, group, newUser, approver) => {
       {
         $inc:
         {
-          joinRequests: -1
+          joinRequests: -1,
+          users: 1
         }
       }
     )

--- a/server/routes/manage/users.js
+++ b/server/routes/manage/users.js
@@ -40,6 +40,7 @@ router.post('/add', async (req, res, next) => {
  *  Query the DB to see if a user already exists in the specific group.
  *
  *  @param {object} db MongoDB connection
+ *  @param {function} next Express middleware
  *  @param {string} newUser New user to give access to the group
  *  @param {string} group Group to verify if user exists in
  *  @returns {boolean} Determines if user exists or not
@@ -62,7 +63,8 @@ const userExists = async (db, next, newUser, group) => {
  *  userAccess object created from supplied data, then inserted
  *  to the 'kgroups_access' collection.
  *
- *  @param {object} db MongoDB Connectioon
+ *  @param {object} db MongoDB Connection
+ *  @param {function} next Express middleware
  *  @param {string} user User currently logged in
  *  @param {string} newUser New user to give access to the group
  *  @param {string} group Group name to add to
@@ -124,7 +126,8 @@ router.post('/delete', async (req, res, next) => {
 /**
  *  Delete a user's access to a community group.
  *
- *  @param {object} db MongoDB Connectioon
+ *  @param {object} db MongoDB Connection
+ *  @param {function} next Express middleware
  *  @param {string} user User to remove access to the group
  *  @param {string} group Group name to remove from
  *  @returns {boolean} Determines if deleting a user was a success
@@ -141,7 +144,15 @@ const deleteUserFromGroup = (db, next, user, group) => {
 }
 
 
-
+/**
+ *  POST route to approve a user's access to a community group.
+ *  Route: /manage/users/approve
+ *
+ *  Gets the local DB object, deconstructs the logged in user,
+ *  user to approve, and group.
+ *  CSRF validation is done. If valid, proceed with database query.
+ *  Databse approve will return object of new user, return response to frontend.
+ */
 router.post('/approve', async (req, res, next) => {
   const db = req.app.locals.db;
   let { group, newUser, user } = req.body;
@@ -159,7 +170,16 @@ router.post('/approve', async (req, res, next) => {
   }
 })
 
-
+/**
+ *  Approve a user's access to a community group.
+ *
+ *  @param {object} db MongoDB Connection
+ *  @param {function} next Express middleware
+ *  @param {string} group Group name to approve from
+ *  @param {string} newUser User to approve access to
+ *  @param {string} user User that's doing the approving
+ *  @returns {object} The newUser data object
+ */
 const approvalJoinGroup = (db, next, group, newUser, approver) => {
   try {
     const created = new Date();
@@ -212,6 +232,15 @@ const approvalJoinGroup = (db, next, group, newUser, approver) => {
   }
 }
 
+/**
+ *  POST route to deny/rejct a user's access to a community group.
+ *  Route: /manage/users/deny
+ *
+ *  Gets the local DB object, deconstructs the logged in user,
+ *  user to approve, and group.
+ *  CSRF validation is done. If valid, proceed with database query.
+ *  Databse deny will return true/false, return response to frontend.
+ */
 router.post('/deny', async (req, res, next) => {
   const db = req.app.locals.db;
   let { group, newUser, user } = req.body;
@@ -226,6 +255,15 @@ router.post('/deny', async (req, res, next) => {
   }
 })
 
+/**
+ *  Deny a user's access to a community group.
+ *
+ *  @param {object} db MongoDB Connection
+ *  @param {function} next Express middleware
+ *  @param {string} group Group name to approve from
+ *  @param {string} newUser User to approve access to
+ *  @returns {boolean} Determines if denying a user was a success
+ */
 const denyJoinGroup = (db, next, group, newUser) => {
   try {
     //Create new access entry for user and group


### PR DESCRIPTION
Some important New Features were added that bring better UX and interactivity to the site.

# New Features
- View Content from Steem
Click on a post title on the Kurate page, and you can view the content of that post!

- Communities Page to View Communities
You can view the `Newly Created` and `Recently Active` communities. They display some data about each community, such as the number of  `Posts` and `Users`, when it was `Created`, and who the `Owner` is.

- User Send Request to Join a Community
If you're not a member of a community, you can click on `Join`. It will then change to `Requested`. If you're already a member, you won't see any option to join.

- Community Staff can Approve or Deny a Request to Join
In the `Manage` section, there is now a `Join Requests` section above the `Members` list. You can see the `User` who requested to join the community, `When` they requested to join, and the actions to `Approve` or `Deny` the request to join.

# Bug Fixes
- Home page not updating when going back to the page
The Home page wasn't fetching new data when the route/page was revisited in the same session. removed an `if()` that was preventing new data fetches solved the issue.

# Other Changes/Improvements
 - Users and Join Request info for Community listed
Some minor changes, but important for the UX (user experience), are some stats for the communities you can see in the `Manage` page. In addition to `Posts`, the `Users` and `Join Requests` are now visible. They will update on-the-fly when you manually add/delete a user, or when approving or denying a user who has requested to join.