### PR TITLE
Delete Posts and Comments, Transfer Ownership of Communities, and Eye Candy on Post Actions

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -6,6 +6,7 @@
 
 body {
   font-size: 1rem;
+  font-family: var(--font-content)
 }
 
 a {

--- a/client/src/actions/authActions.js
+++ b/client/src/actions/authActions.js
@@ -229,7 +229,7 @@ export const cookieUser = () => {
  *  @returns {function} Dispatches returned action object
  */
 export const handleReturning = () => (dispatch, getState) => {
-  const {isAuth, isAuthorizing} = getState().auth;
+  const { isAuth, isAuthorizing } = getState().auth;
   if (!isAuth && !isAuthorizing)
     return dispatch(fetchReturning());
 }

--- a/client/src/actions/commentsActions.js
+++ b/client/src/actions/commentsActions.js
@@ -1,10 +1,15 @@
 import { Client } from 'dsteem';
 
+import SteemConnect from '../utils/auth/scAPI';
+import { deletePayloadSuccess } from './sendCommentActions';
+
 const client = new Client('https://hive.anyx.io/');
 
 export const GET_COMMENTS_START = 'GET_COMMENTS_START';
 export const GET_COMMENTS_SUCCESS = 'GET_COMMENTS_SUCCESS';
 export const CLEAR_COMMENTS = 'CLEAR_COMMENTS';
+export const DELETE_COMMENT_START = 'DELETE_COMMENT_START';
+export const DELETE_COMMENT_SUCCESS = 'DELETE_COMMENT_SUCCESS';
 
 /**
  *  Action creator for starting retrieval of comments data.
@@ -21,7 +26,7 @@ export const commentsStart = () => ({
  *  @param {object} comments Post to display
  *  @return {object} The action data
  */
-export const commentsSuccess = (comments) => ({
+export const commentsSuccess = comments => ({
   type: GET_COMMENTS_SUCCESS,
   comments,
 });
@@ -29,11 +34,34 @@ export const commentsSuccess = (comments) => ({
 /**
  *  Action creator for clearning comments data.
  *
- *  @param {object} comments Post to display
  *  @return {object} The action data
  */
 export const commentsClear = () => ({
   type: CLEAR_COMMENTS,
+});
+
+/**
+ *  Action creator for starting to delete a comment.
+ *
+ *  @param {string} author Author of post
+ *  @param {string} permlink Permlink of post
+ *  @return {object} The action data
+ */
+export const deleteCommentStart = (author, permlink) => ({
+  type: DELETE_COMMENT_START,
+  author,
+  permlink,
+});
+
+/**
+ *  Action creator for successfully deleting a comment.
+ *
+ *  @param {object} newReplies New replies object filtered
+ *  @return {object} The action data
+ */
+export const deleteCommentSuccess = newReplies => ({
+  type: DELETE_COMMENT_SUCCESS,
+  newReplies,
 });
 
 /**
@@ -82,6 +110,66 @@ const postCommentsRecursive = (author, permlink) => {
         return r;
       }
     })))
+}
+
+/**
+ *  Delete a comment from a post by using author and permlink to refrence it.
+ *  Once deleted, remove from the existing data to exclude it from the view.
+ *
+ *  @param {string} author Author of comment
+ *  @param {string} permlink Permlink of comment
+ *  @returns {function} Dispatches returned action object
+ */
+export const deleteComment = (author, permlink, commentPayload = {}) => (dispatch, getState) => {
+  dispatch(deleteCommentStart(author, permlink));
+
+  const { replies } = getState().comments;
+
+  return SteemConnect
+    .deleteComment(author, permlink)
+    .then(res => {
+      if (res.result.block_num) {
+
+        let newCommentPayload = {...commentPayload};
+
+        // first, if new comments were added, check those for the comment
+        // to delete
+        for (let key in commentPayload) {
+          newCommentPayload[key] = commentPayload[key].filter(c => c.permlink !== permlink);
+        }
+
+        // if no new comment was deleted, then interate over the existing
+        // comments to find and remove the comment
+        if (JSON.stringify(newCommentPayload) === JSON.stringify(commentPayload)) {
+          deleteRecursive(permlink, replies)
+            .then(newReplies => dispatch(deleteCommentSuccess(newReplies)));
+        }else {
+          dispatch(deletePayloadSuccess(newCommentPayload));
+        }
+      }
+    });
+}
+
+/**
+ *  Recursively iterate through the replies and return all the replies,
+ *  including children replies, that aren't the comment being deleted.
+ *
+ *  @param {string} permlink Permlink of comment
+ *  @param {object} replies Permlink of comment
+ *  @returns {function} Dispatches returned action object
+ */
+const deleteRecursive = (permlink, replies = {}) => {
+  return Promise.all(replies.filter(r => {
+    if (r.children > 0) {
+      return deleteRecursive(permlink, r.replies)
+        .then(children => {
+          r.replies = children;
+          return r;
+        })
+    }else {
+      return r.permlink !== permlink;
+    }
+  }))
 }
 
 export default getPostComments;

--- a/client/src/actions/communitiesActions.js
+++ b/client/src/actions/communitiesActions.js
@@ -107,10 +107,10 @@ export const getGroupData = (group, limit, nextId) => (dispatch, getState) => {
  *  @param {string} group Group to request join for
  *  @returns {function} Dispatches returned action object
  */
-export const joinGroup = async group => (dispatch, getState) => {
-  dispatch(joinGroupStart());
+export const joinGroup = group => (dispatch, getState) => {
+  dispatch(joinGroupStart(group));
 
-  const { state } = getState();
+  const state = getState();
   const {
     auth: {
       user,
@@ -120,10 +120,12 @@ export const joinGroup = async group => (dispatch, getState) => {
 
   return requestToJoinGroup({group, user}, csrf)
   .then(result => {
-    const { groupData } = state;
+
+    const { groupData } = state.communities;
+
     let kaccess = groupData.kaccess;
 
-    if (result.data.group) {
+    if (result.data) {
       kaccess[0] = { access: 100 };
     }
 

--- a/client/src/actions/detailsPostActions.js
+++ b/client/src/actions/detailsPostActions.js
@@ -1,5 +1,6 @@
 import { Client } from 'dsteem';
 
+import SteemConnect from '../utils/auth/scAPI';
 import { getUserGroupsFetch } from './userGroupsActions';
 import { getPostComments } from './commentsActions';
 
@@ -8,6 +9,8 @@ const client = new Client('https://hive.anyx.io/');
 export const GET_DETAILS_START = 'GET_DETAILS_START';
 export const GET_DETAILS_SUCCESS = 'GET_DETAILS_SUCCESS';
 export const CLEAR_POST = 'CLEAR_POST';
+export const DELETE_POST_START = 'DELETE_POST_START';
+export const DELETE_POST_SUCCESS = 'DELETE_POST_SUCCESS';
 
 /**
  *  Action creator for starting retrieval of post detail data.
@@ -39,6 +42,25 @@ export const clearPost = () => ({
 });
 
 /**
+ *  Action creator for starting to delete a post.
+ *
+ *  @return {object} The action data
+ */
+export const deletePostStart = () => ({
+  type: DELETE_POST_START,
+});
+
+/**
+ *  Action creator for successfully deleting a post.
+ *
+ *  @return {object} The action data
+ */
+export const deletePostSuccess = (redirect) => ({
+  type: DELETE_POST_SUCCESS,
+  redirect,
+});
+
+/**
  *  Fetch the post details from Steem.
  *
  *  @param {string} author Author of post
@@ -61,6 +83,28 @@ export const getDetailsContent = (author, permlink) => (dispatch, getState) => {
         dispatch(getPostComments(post.author, post.permlink));
       }
     })
+}
+
+/**
+ *  Delete a post by using author and permlink to refrence it.
+ *
+ *  @param {string} author Author of comment
+ *  @param {string} permlink Permlink of comment
+ *  @returns {function} Dispatches returned action object
+ */
+export const deletePost = (author, permlink) => (dispatch, getState) => {
+  dispatch(deletePostStart());
+
+  return SteemConnect
+    .deleteComment(author, permlink)
+    .then(res => {
+console.log('res',res)
+      if (res.result.block_num) {
+        const { user } = getState().auth;
+        const redirect = `/@${user}/`;
+        dispatch(deletePostSuccess(redirect));
+      }
+    });
 }
 
 export default getDetailsContent;

--- a/client/src/actions/detailsPostActions.js
+++ b/client/src/actions/detailsPostActions.js
@@ -2,7 +2,6 @@ import { Client } from 'dsteem';
 
 import { getUserGroupsFetch } from './userGroupsActions';
 import { getPostComments } from './commentsActions';
-import { clearNewPost } from './sendPostActions';
 
 const client = new Client('https://hive.anyx.io/');
 

--- a/client/src/actions/detailsPostActions.js
+++ b/client/src/actions/detailsPostActions.js
@@ -98,7 +98,6 @@ export const deletePost = (author, permlink) => (dispatch, getState) => {
   return SteemConnect
     .deleteComment(author, permlink)
     .then(res => {
-console.log('res',res)
       if (res.result.block_num) {
         const { user } = getState().auth;
         const redirect = `/@${user}/`;

--- a/client/src/actions/sendCommentActions.js
+++ b/client/src/actions/sendCommentActions.js
@@ -11,6 +11,7 @@ export const GET_COMMENT_START = 'GET_COMMENT_START';
 export const GET_COMMENT_SUCCESS = 'GET_COMMENT_START';
 export const EDIT_COMMENT_START = 'EDIT_COMMENT_START';
 export const EDIT_COMMENT_SUCCESS = 'EDIT_COMMENT_SUCCESS';
+export const DELETE_COMMENT_START = 'DELETE_COMMENT_START';
 
 /**
  *  Action creator for starting to send a comment.
@@ -18,8 +19,9 @@ export const EDIT_COMMENT_SUCCESS = 'EDIT_COMMENT_SUCCESS';
  *  @param {string} parentId Id of parent post being commented on
  *  @return {object} The action data
  */
-export const sendCommentStart = () => ({
+export const sendCommentStart = (parentId) => ({
   type: SEND_COMMENT_START,
+  parentId,
 });
 
 /**
@@ -59,6 +61,16 @@ export const editCommentSuccess = comment => ({
 });
 
 /**
+ *  Action creator for starting to delete a comment.
+ *
+ *  @param {string} parentId Id of parent post being commented on
+ *  @return {object} The action data
+ */
+export const deleteCommentStart = () => ({
+  type: DELETE_COMMENT_START,
+});
+
+/**
  *  Uses SteemConnect to send a comment to the Steem blockchain.
  *
  *  @param {string} parentPost Parent being commented on
@@ -66,14 +78,15 @@ export const editCommentSuccess = comment => ({
  *  @returns {function} Dispatches returned action object
  */
 export const sendComment = (body, parentPost) => (dispatch, getState) => {
-  dispatch(sendCommentStart());
+  const { category, id, permlink: parentPermlink, author: parentAuthor } = parentPost;
+
   const {
     auth: {
       user
     },
   } = getState();
 
-  const { category, id, permlink: parentPermlink, author: parentAuthor } = parentPost;
+  dispatch(sendCommentStart(id));
 
   const author = user;
   const permlink = createCommentPermlink(parentAuthor, parentPermlink)
@@ -128,6 +141,24 @@ export const getComment = (author, permlink) => {
       resolve(comment);
     });
   });
+}
+
+export const deleteComment = (author, permlink) => dispatch => {
+  dispatch(deleteCommentStart());
+
+  return SteemConnect
+    .deleteComment(author, permlink)
+    .then(res => {
+console.log('res',res)
+      //dispatch(deleteCommentSuccess());
+
+      /*if (res.result.block_num) {
+        getComment(author, permlink)
+          .then(comment => {
+            dispatch(editCommentSuccess(comment));
+          })
+      }*/
+    });
 }
 
 export default sendComment;

--- a/client/src/actions/sendCommentActions.js
+++ b/client/src/actions/sendCommentActions.js
@@ -11,7 +11,8 @@ export const GET_COMMENT_START = 'GET_COMMENT_START';
 export const GET_COMMENT_SUCCESS = 'GET_COMMENT_START';
 export const EDIT_COMMENT_START = 'EDIT_COMMENT_START';
 export const EDIT_COMMENT_SUCCESS = 'EDIT_COMMENT_SUCCESS';
-export const DELETE_COMMENT_START = 'DELETE_COMMENT_START';
+export const SEND_COMMENT_CLEAR = 'SEND_COMMENT_CLEAR';
+export const DELETE_PAYLOAD_SUCCESS = 'DELETE_PAYLOAD_SUCCESS';
 
 /**
  *  Action creator for starting to send a comment.
@@ -19,7 +20,7 @@ export const DELETE_COMMENT_START = 'DELETE_COMMENT_START';
  *  @param {string} parentId Id of parent post being commented on
  *  @return {object} The action data
  */
-export const sendCommentStart = (parentId) => ({
+const sendCommentStart = (parentId) => ({
   type: SEND_COMMENT_START,
   parentId,
 });
@@ -31,7 +32,7 @@ export const sendCommentStart = (parentId) => ({
  *  @param {string} parentId Id of parent post being commented on
  *  @return {object} The action data
  */
-export const sendCommentSuccess = (comment, parentId) => ({
+const sendCommentSuccess = (comment, parentId) => ({
   type: SEND_COMMENT_SUCCESS,
   comment,
   parentId,
@@ -43,7 +44,7 @@ export const sendCommentSuccess = (comment, parentId) => ({
  *  @param {string} parentId Id of parent post being commented on
  *  @return {object} The action data
  */
-export const editCommentStart = id => ({
+const editCommentStart = id => ({
   type: EDIT_COMMENT_START,
   id,
 });
@@ -55,19 +56,29 @@ export const editCommentStart = id => ({
  *  @param {string} parentId Id of parent post being commented on
  *  @return {object} The action data
  */
-export const editCommentSuccess = comment => ({
+const editCommentSuccess = comment => ({
   type: EDIT_COMMENT_SUCCESS,
   comment,
 });
 
 /**
- *  Action creator for starting to delete a comment.
+ *  Action creator for clearing the send comment variables.
  *
- *  @param {string} parentId Id of parent post being commented on
  *  @return {object} The action data
  */
-export const deleteCommentStart = () => ({
-  type: DELETE_COMMENT_START,
+export const sendCommentClear = () => ({
+  type: SEND_COMMENT_CLEAR,
+});
+
+/**
+ *  Action creator for successfully deleting a comment recently submitted.
+ *
+ *  @param {string} newReplies New replies object filtered
+ *  @return {object} The action data
+ */
+export const deletePayloadSuccess = newCommentPayload => ({
+  type: DELETE_PAYLOAD_SUCCESS,
+  newCommentPayload,
 });
 
 /**
@@ -108,6 +119,16 @@ export const sendComment = (body, parentPost) => (dispatch, getState) => {
     });
 }
 
+/**
+ *  Editing a comment is done with the body from the form which will replace
+ *  the previous comment body. The data from the comment is extracted and
+ *  used to upadte the comment in question, and also to fetch it anew once
+ *  the comment is updated.
+ *
+ *  @param {string} body Body of comment to update
+ *  @param {string} comment Comment being updated
+ *  @returns {function} Dispatches returned action object
+ */
 export const editComment = (body, comment) => dispatch => {
   dispatch(editCommentStart(comment.id));
 
@@ -141,24 +162,6 @@ export const getComment = (author, permlink) => {
       resolve(comment);
     });
   });
-}
-
-export const deleteComment = (author, permlink) => dispatch => {
-  dispatch(deleteCommentStart());
-
-  return SteemConnect
-    .deleteComment(author, permlink)
-    .then(res => {
-console.log('res',res)
-      //dispatch(deleteCommentSuccess());
-
-      /*if (res.result.block_num) {
-        getComment(author, permlink)
-          .then(comment => {
-            dispatch(editCommentSuccess(comment));
-          })
-      }*/
-    });
 }
 
 export default sendComment;

--- a/client/src/actions/sendPostActions.js
+++ b/client/src/actions/sendPostActions.js
@@ -74,7 +74,13 @@ const rewardsValues = {
   none: '0',
 };
 
-
+/**
+ *  Extract some data from the post, and send it back as a post draft for the
+ *  edit form to display and allow the user to edit.
+ *
+ *  @param {string} post Post object to edited
+ *  @returns {function} Dispatches returned action object
+ */
 export const editPost = post => dispatch => {
   const jsonMetadata = jsonParse(post.json_metadata);
 
@@ -89,10 +95,10 @@ export const editPost = post => dispatch => {
 }
 
 /**
- *  Uses SteemConnect to send a comment to the Steem blockchain.
+ *  Uses SteemConnect to send a post to the Steem blockchain. This is either a
+ *  new post, or to edit a post.
  *
- *  @param {string} parentPost Parent being commented on
- *  @param {string} body Comment body
+ *  @param {string} post Post object to be sent or updated
  *  @returns {function} Dispatches returned action object
  */
 export const sendPost = post => (dispatch, getState) => {
@@ -178,9 +184,15 @@ export const sendPost = post => (dispatch, getState) => {
           setTimeout(() => dispatch(sendPostSuccess(redirect)), 1500);
       });
   })
-
 }
 
+/**
+ *  Delete a post by using author and permlink to refrence it.
+ *
+ *  @param {string} author Author of comment
+ *  @param {string} permlink Permlink of comment
+ *  @returns {function} Dispatches returned action object
+ */
 export const deletePost = (author, permlink) => dispatch => {
   dispatch(deletePostStart());
 

--- a/client/src/actions/sendPostActions.js
+++ b/client/src/actions/sendPostActions.js
@@ -8,6 +8,7 @@ export const SEND_POST_ERROR = 'SEND_POST_ERROR';
 export const CLEAR_NEW_POST = 'CLEAR_NEW_POST';
 export const SHOW_EDIT_POST = 'SHOW_EDIT_POST';
 export const CANCEL_EDIT_POST = 'CANCEL_EDIT_POST';
+export const DELETE_POST_START = 'DELETE_POST_START';
 
 /**
  *  Action creator for starting to send a post.
@@ -65,6 +66,16 @@ const showEditPost = (draft) => ({
  */
 export const cancelEditPost = () => ({
   type: CANCEL_EDIT_POST,
+});
+
+/**
+ *  Action creator for starting to delete a comment.
+ *
+ *  @param {string} parentId Id of parent post being commented on
+ *  @return {object} The action data
+ */
+export const deletePostStart = () => ({
+  type: DELETE_POST_START,
 });
 
 const rewardsValues = {
@@ -164,18 +175,39 @@ export const sendPost = post => (dispatch, getState) => {
     const now = Date.now();
     const lastPosted = localStorage.getItem('lastPostedAt-' + user);
 
+    const redirect = `/${parentPermlink}/@${author}/${permlink}`;
+console.log('redirect',redirect)
+
     //Check if last post was less than 5 minuts ago.
     //Send error message or send post to Steem if under or over 5 minutes.
-    if (lastPosted && (now - lastPosted) < 300000)
+    /*if (lastPosted && (now - lastPosted) < 300000)
       return dispatch(sendPostError('Must wait 5 minutes between posts.'));
     else
       return SteemConnect.broadcast(operations)
         .then(res => {
           localStorage.setItem('lastPostedAt-' + user, now);
-          setTimeout(() => dispatch(sendPostSuccess(`/${parentPermlink}/@${author}/${permlink}`)), 1500);
-      });
+          setTimeout(() => dispatch(sendPostSuccess(redirect)), 1500);
+      });*/
   })
 
+}
+
+export const deletePost = (author, permlink) => dispatch => {
+  dispatch(deletePostStart());
+
+  return SteemConnect
+    .deleteComment(author, permlink)
+    .then(res => {
+console.log('res',res)
+      //dispatch(deleteCommentSuccess());
+
+      /*if (res.result.block_num) {
+        getComment(author, permlink)
+          .then(comment => {
+            dispatch(editCommentSuccess(comment));
+          })
+      }*/
+    });
 }
 
 export default sendPost;

--- a/client/src/actions/sendPostActions.js
+++ b/client/src/actions/sendPostActions.js
@@ -7,7 +7,6 @@ export const SEND_POST_SUCCESS = 'SEND_POST_SUCCESS';
 export const SEND_POST_ERROR = 'SEND_POST_ERROR';
 export const CLEAR_NEW_POST = 'CLEAR_NEW_POST';
 export const SHOW_EDIT_POST = 'SHOW_EDIT_POST';
-export const DELETE_POST_START = 'DELETE_POST_START';
 
 /**
  *  Action creator for starting to send a post.
@@ -58,15 +57,7 @@ const showEditPost = (draft) => ({
   draft,
 });
 
-/**
- *  Action creator for starting to delete a comment.
- *
- *  @param {string} parentId Id of parent post being commented on
- *  @return {object} The action data
- */
-export const deletePostStart = () => ({
-  type: DELETE_POST_START,
-});
+
 
 const rewardsValues = {
   all: '100',
@@ -184,31 +175,6 @@ export const sendPost = post => (dispatch, getState) => {
           setTimeout(() => dispatch(sendPostSuccess(redirect)), 1500);
       });
   })
-}
-
-/**
- *  Delete a post by using author and permlink to refrence it.
- *
- *  @param {string} author Author of comment
- *  @param {string} permlink Permlink of comment
- *  @returns {function} Dispatches returned action object
- */
-export const deletePost = (author, permlink) => dispatch => {
-  dispatch(deletePostStart());
-
-  return SteemConnect
-    .deleteComment(author, permlink)
-    .then(res => {
-console.log('res',res)
-      //dispatch(deleteCommentSuccess());
-
-      /*if (res.result.block_num) {
-        getComment(author, permlink)
-          .then(comment => {
-            dispatch(editCommentSuccess(comment));
-          })
-      }*/
-    });
 }
 
 export default sendPost;

--- a/client/src/actions/sendPostActions.js
+++ b/client/src/actions/sendPostActions.js
@@ -7,7 +7,6 @@ export const SEND_POST_SUCCESS = 'SEND_POST_SUCCESS';
 export const SEND_POST_ERROR = 'SEND_POST_ERROR';
 export const CLEAR_NEW_POST = 'CLEAR_NEW_POST';
 export const SHOW_EDIT_POST = 'SHOW_EDIT_POST';
-export const CANCEL_EDIT_POST = 'CANCEL_EDIT_POST';
 export const DELETE_POST_START = 'DELETE_POST_START';
 
 /**
@@ -24,9 +23,9 @@ const sendPostStart = () => ({
  *
  *  @return {object} The action data
  */
-const sendPostSuccess = newPost => ({
+const sendPostSuccess = redirect => ({
   type: SEND_POST_SUCCESS,
-  newPost,
+  redirect,
 });
 
 /**
@@ -45,7 +44,7 @@ const sendPostError = error => ({
  *
  *  @return {object} The action data
  */
-export const clearNewPost = () => ({
+export const clearSendPost = () => ({
   type: CLEAR_NEW_POST,
 });
 
@@ -57,15 +56,6 @@ export const clearNewPost = () => ({
 const showEditPost = (draft) => ({
   type: SHOW_EDIT_POST,
   draft,
-});
-
-/**
- *  Action creator for clearing a new post after the page is loaded.
- *
- *  @return {object} The action data
- */
-export const cancelEditPost = () => ({
-  type: CANCEL_EDIT_POST,
 });
 
 /**
@@ -147,6 +137,8 @@ export const sendPost = post => (dispatch, getState) => {
     ];
     operations.push(commentOp);
 
+    const redirect = `/${parentPermlink}/@${author}/${permlink}`;
+
     if (isUpdating) {
       return SteemConnect.broadcast(operations)
         .then(res => {
@@ -175,19 +167,16 @@ export const sendPost = post => (dispatch, getState) => {
     const now = Date.now();
     const lastPosted = localStorage.getItem('lastPostedAt-' + user);
 
-    const redirect = `/${parentPermlink}/@${author}/${permlink}`;
-console.log('redirect',redirect)
-
     //Check if last post was less than 5 minuts ago.
     //Send error message or send post to Steem if under or over 5 minutes.
-    /*if (lastPosted && (now - lastPosted) < 300000)
+    if (lastPosted && (now - lastPosted) < 300000)
       return dispatch(sendPostError('Must wait 5 minutes between posts.'));
     else
       return SteemConnect.broadcast(operations)
         .then(res => {
           localStorage.setItem('lastPostedAt-' + user, now);
           setTimeout(() => dispatch(sendPostSuccess(redirect)), 1500);
-      });*/
+      });
   })
 
 }

--- a/client/src/actions/summaryPostActions.js
+++ b/client/src/actions/summaryPostActions.js
@@ -7,6 +7,7 @@ const client = new Client('https://hive.anyx.io/');
 
 export const GET_SUMMARY_START = 'GET_SUMMARY_START';
 export const GET_SUMMARY_SUCCESS = 'GET_SUMMARY_SUCCESS';
+export const SUMMARY_CANCEL = 'SUMMARY_CANCEL';
 
 /**
  *  Action creator for starting retrieval of post summary data.
@@ -32,6 +33,15 @@ export const summarySuccess = (posts, hasMore, prevPage, startAuthor, startPerml
   startPermlink,
 });
 
+/**
+ *  Action creator for starting retrieval of post summary data.
+ *
+ *  @return {object} The action data
+ */
+export const summaryCancel = (prevPage) => ({
+  type: SUMMARY_CANCEL,
+  prevPage,
+});
 
 /**
  *  Fetch the post details from Steem.
@@ -74,6 +84,10 @@ export const getSummaryContent = (selectedFilter, query, page, action) => (dispa
     .then(result => {
       let hasMore = true;
       let newPosts = null;
+
+      if (!result.length && !posts.length) {
+        return dispatch(summaryCancel(page));
+      }
 
       if (result) {
         if (nextPost) {

--- a/client/src/actions/userGroupsActions.js
+++ b/client/src/actions/userGroupsActions.js
@@ -55,7 +55,7 @@ export const getUserGroupsFetch = () => (dispatch, getState) => {
   if (!groups.length || groups[0].text !== "No Groups") return;
 
   return getUserGroups(user, 'all')
-    .then(res => {
+    .then(res => {   
       const groups = res.data.groups.map((g, i) => {
         return {key: i, value: g.name, text: g.display}
       })

--- a/client/src/components/kure/GroupPostsList.js
+++ b/client/src/components/kure/GroupPostsList.js
@@ -70,7 +70,7 @@ const GroupPostsList = (props) => {
                     access < roles.kGroupsRolesRev['Member']
                     && (
                       <a href={'/post/delete/'+p.st_author+'/'+p.st_permlink} onClick={e => showModal(e, {author: p.st_author, post: p.st_permlink})}>
-                        <Icon name='delete' color='blue' />
+                        <Icon name='delete' color='red' />
                       </a>
                     )
                   }

--- a/client/src/components/kure/GroupUsers.js
+++ b/client/src/components/kure/GroupUsers.js
@@ -56,7 +56,7 @@ const GroupUsers = ({users, showModal, deletingUser, user, access}) => (
                         access < roles.kGroupsRolesRev['Moderator']
                         ? (u.access !== 0 && access < u.access)
                           ?
-                            <a href={`/users/delete/${u.user}/`} onClick={e => showModal(e, {user: u.user})}><Icon name='delete' color='blue' /></a>
+                            <a href={`/users/delete/${u.user}/`} onClick={e => showModal(e, {user: u.user})}><Icon name='delete' color='red' /></a>
                           : ''
                         : ''
                       }

--- a/client/src/components/pages/Groups/GroupDetails.js
+++ b/client/src/components/pages/Groups/GroupDetails.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import { connect } from 'react-redux';
-import { Grid, Label, Header, Segment } from "semantic-ui-react";
+import { Grid, Label, Header, Segment, Dimmer, Loader } from "semantic-ui-react";
 import PropTypes from 'prop-types';
 
 import Loading from '../../Loading/Loading';
@@ -32,6 +32,7 @@ class GroupDetails extends Component {
     getContent: PropTypes.func,
     joinGroupRequest: PropTypes.func,
     groupRequested: PropTypes.string,
+    isJoining: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -43,6 +44,7 @@ class GroupDetails extends Component {
     getContent: () => {},
     joinGroupRequest: () => {},
     groupRequested: '',
+    isJoining: false,
   };
 
   constructor(props) {
@@ -174,6 +176,7 @@ class GroupDetails extends Component {
         groupData,
         isFetching,
         groupRequested,
+        isJoining,
       }
     } = this;
 
@@ -244,6 +247,7 @@ class GroupDetails extends Component {
                           {tabViews}
                           { isAuth && (
                             <Label size='large'>
+                              { isJoining && <Dimmer inverted active={isJoining}><Loader size='tiny' inline /></Dimmer> }
                               {'Membership: '}
                               {
                                 joinCommunities(isAuth, groupRequested, groupData.name, groupData.kaccess[0], this.onJoinGroup)
@@ -290,6 +294,7 @@ const mapStateToProps = state => {
     communities: {
       isFetching,
       groupData,
+      isJoining,
     }
   } = state;
 
@@ -297,6 +302,7 @@ const mapStateToProps = state => {
     isAuth,
     isFetching,
     groupData,
+    isJoining,
   }
 }
 
@@ -314,8 +320,8 @@ const mapDispatchToProps = dispatch => (
     clearContent: () => (
       dispatch(groupClear())
     ),
-    joinGroupRequest: () => (
-      dispatch(joinGroup())
+    joinGroupRequest: (group) => (
+      dispatch(joinGroup(group))
     ),
   }
 );

--- a/client/src/components/pages/Groups/GroupDetails.js
+++ b/client/src/components/pages/Groups/GroupDetails.js
@@ -222,7 +222,7 @@ class GroupDetails extends Component {
 
     return (
       !groupData.notExists
-      ? groupData.kposts.length
+      ? groupData.display
         ? (
           <ErrorBoundary>
             <div className='community'>

--- a/client/src/components/pages/Groups/GroupDetails.js
+++ b/client/src/components/pages/Groups/GroupDetails.js
@@ -68,18 +68,8 @@ class GroupDetails extends Component {
   }
 
   /**
-   *  Fetch post detail from Steem blockchain on component update.
+   *  Remove scoll window listener and clear the group redux content.
    */
-  /*componentDidUpdate(prevProps) {
-    const {
-      user,
-    } = this.props;
-
-    if (prevProps.user !== user) {
-      this.getPosts();
-    }
-  }*/
-
   componentWillUnmount() {
     window.removeEventListener("scroll", this.handleScroll);
 
@@ -186,9 +176,15 @@ class GroupDetails extends Component {
         ? <GroupPostsGrid posts={groupData.kposts} />
         : <GroupPostsList posts={groupData.kposts} />
       : (
-        <Segment>
-          {'No posts.'}
-        </Segment>
+        <Grid>
+          <Grid.Column>
+            <div>
+              <Segment floated='left'>
+                {'No posts.'}
+              </Segment>
+            </div>
+          </Grid.Column>
+        </Grid>
       );
 
 

--- a/client/src/components/pages/Groups/Groups.css
+++ b/client/src/components/pages/Groups/Groups.css
@@ -17,3 +17,12 @@
 .newlyCreated .ui.label {
   margin-bottom: 1rem;
 }
+
+.community .ui.label a {
+  color: #21ba45;
+  opacity: 1;
+}
+
+.community .ui.label a:hover {
+  color: #198f35;
+}

--- a/client/src/components/pages/Manage/GroupManage.js
+++ b/client/src/components/pages/Manage/GroupManage.js
@@ -37,7 +37,7 @@ class GroupManage extends Component {
     onPostUpdate: PropTypes.func.isRequired,
     onUserUpdate: PropTypes.func.isRequired,
     onJoinRequestUpdate: PropTypes.func.isRequired,
-
+    handleChangeOwner: PropTypes.func.isRequired,
   };
 
   constructor(props) {
@@ -53,6 +53,8 @@ class GroupManage extends Component {
       pending: [],
       approvingUser: '',
       group: '',
+      access: 4, //guest access
+      groupName: '',
       modalOpen: false,
       modalData: {},
       newUser: '',
@@ -81,13 +83,16 @@ class GroupManage extends Component {
    *  @param {object} state Current state object
    */
   static getDerivedStateFromProps(props, state) {
-    const group = props.manageGroup.group['name'];
+    const { manageGroup } = props;
+    const group = manageGroup.group['name'];
     if (group !== state.group) {
       return {
         group: group,
-        posts: props.manageGroup.posts,
-        users: props.manageGroup.users,
-        pending: props.manageGroup.pending
+        access: manageGroup.group.access.access,
+        groupName: manageGroup.group.display,
+        posts: manageGroup.posts,
+        users: manageGroup.users,
+        pending: manageGroup.pending
       };
     }
     return null;
@@ -499,27 +504,8 @@ class GroupManage extends Component {
     .then(res => {
       if (!res.data.invalidCSRF) {
         if (res.data) {
-          const { users } = this.state;
-
-          const newUsers = users.map(u => {
-            if (newOwner === u.user) {
-              u = {
-                ...u,
-                access: 0,
-              };
-            }else if (this.user === u.user) {
-              u = {
-                ...u,
-                access: 3,
-              };
-            }
-            return u;
-          });
-
-          this.setState({
-            users: newUsers,
-            newOwnerLoading: false,
-          });
+          const { handleChangeOwner } = this.props;
+          handleChangeOwner();
         }
       }
     }).catch(err => {
@@ -546,14 +532,9 @@ class GroupManage extends Component {
       deletingUser,
       newOwner,
       newOwnerLoading,
+      access,
+      groupName,
     } = this.state;
-
-    const {
-      manageGroup,
-    } = this.props;
-
-    const access = manageGroup.group.access.access;
-    const groupName = manageGroup.group.display;
 
     let addErrorPost = '';
     let addErrorUser = '';

--- a/client/src/components/pages/Manage/GroupManage.js
+++ b/client/src/components/pages/Manage/GroupManage.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import { Grid, Header, Icon, Form, Label, Divider } from "semantic-ui-react";
+import { Grid, Header, Icon, Form, Label, Divider, Segment } from "semantic-ui-react";
 
 import ErrorLabel from '../../ErrorLabel/ErrorLabel';
 import GroupManagePosts from './GroupManagePosts';
@@ -8,7 +8,7 @@ import GroupManageUsers from './GroupManageUsers';
 import ModalConfirm from '../../Modal/ModalConfirm';
 import Picker from '../../Picker/Picker';
 import {roles} from '../../../settings';
-import { addPost, deletePost, addUser, deleteUser, approveUser, denyUser } from '../../../utils/fetchFunctions';
+import { addPost, deletePost, addUser, deleteUser, approveUser, denyUser, changeOwner, logger } from '../../../utils/fetchFunctions';
 import { postValidation, userValidation } from '../../../utils/validationFunctions';
 
 /**
@@ -60,8 +60,9 @@ class GroupManage extends Component {
       addUserLoading: false,
       deletingPost: '',
       deletingUser: '',
-      selectedAccess: Object.keys(roles.kGroupsAccess).find(key => roles.kGroupsAccess[key] === 'Member')
-
+      selectedAccess: Object.keys(roles.kGroupsAccess).find(key => roles.kGroupsAccess[key] === 'Member'),
+      newOwner: '',
+      newOwnerLoading: false,
     };
 
     this.existPost = "Post already in group.";
@@ -463,6 +464,69 @@ class GroupManage extends Component {
     });
   }
 
+  /**
+   *  Validate then add new user to database.
+   *  Trim user name, validate it's structure, set loading flag.
+   */
+  handleSubmitChangeOwner = () => {
+
+    let { newOwner } = this.state;
+    newOwner = newOwner.trim();
+
+    if (this.handleOwnerValidation(newOwner)) {
+      this.setState({ newOwnerLoading: true });
+      const { group } = this.state;
+
+      this.changeOwnerFetch(newOwner, group);
+    }
+  }
+
+  handleOwnerValidation = (newOwner) => {
+    let errors = {};
+    const { users } = this.state;
+
+    const valid = users.some(u => u.user === newOwner);
+
+    if (!valid) errors['newOwner'] = 'New owner must be a member.'
+
+    this.setState({ errors: errors });
+
+    return valid;
+  }
+
+  changeOwnerFetch = (newOwner, group) => {
+    changeOwner({group, user: this.user, newOwner}, this.csrf)
+    .then(res => {
+      if (!res.data.invalidCSRF) {
+        if (res.data) {
+          const { users } = this.state;
+
+          const newUsers = users.map(u => {
+            if (newOwner === u.user) {
+              u = {
+                ...u,
+                access: 0,
+              };
+            }else if (this.user === u.user) {
+              u = {
+                ...u,
+                access: 3,
+              };
+            }
+            return u;
+          });
+
+          this.setState({
+            users: newUsers,
+            newOwnerLoading: false,
+          });
+        }
+      }
+    }).catch(err => {
+      logger('error', err, 'Error modifying ownership.');
+    });
+  }
+
   render() {
     const {
       newPost,
@@ -480,6 +544,8 @@ class GroupManage extends Component {
       addUserLoading,
       deletingPost,
       deletingUser,
+      newOwner,
+      newOwnerLoading,
     } = this.state;
 
     const {
@@ -487,9 +553,11 @@ class GroupManage extends Component {
     } = this.props;
 
     const access = manageGroup.group.access.access;
+    const groupName = manageGroup.group.display;
 
     let addErrorPost = '';
     let addErrorUser = '';
+    let addErrorOwner = '';
 
     if (postExists) addErrorPost = <ErrorLabel text={this.existPost} />;
     if (errors["newPost"] !== undefined) addErrorPost = <ErrorLabel text={errors["newPost"]} />;
@@ -497,20 +565,22 @@ class GroupManage extends Component {
     if (userExists) addErrorUser = <ErrorLabel text={this.existUser} />;
     if (errors["newUser"] !== undefined) addErrorUser = <ErrorLabel text={errors["newUser"]} />;
 
+    if (errors["newOwner"] !== undefined) addErrorOwner = <ErrorLabel text={errors["newOwner"]} />;
+
     return (
       <React.Fragment>
         <Divider />
         <Grid.Row className="header-row">
           <Grid.Column floated='left' width={8}>
             <Header as='h2'>
-              <Label size='big' color='blue'>Managing Group:</Label>
+              <Label size='big' color='blue'>Managing:</Label>
               {'   '}
-              {manageGroup.group.display}
+              {groupName}
             </Header>
           </Grid.Column>
           <Grid.Column floated='right' width={8}>
-            <div className='left'><Header>Posts</Header></div>
-            <div className="">
+            <div className='left'><Label size='big' basic>Posts</Label></div>
+            <div>
               <Form size="tiny" onSubmit={this.handleSubmitNewPost}>
                 <Form.Group className='right'>
                   <Form.Field>
@@ -553,59 +623,103 @@ class GroupManage extends Component {
         <Divider />
         <Grid.Row centered className='noPadBottom'>
           <Grid.Column width={8} floated='right'>
-            <Header>Users</Header>
+            <Label size='big' basic>Users</Label>
           </Grid.Column>
         </Grid.Row>
         <Grid.Row className="content">
-
-          <GroupManageUsers
-            users={users}
-            showModal={this.showModal}
-            deletingUser={deletingUser}
-            access={access}
-            pending={pending}
-            handleApproval={this.handleApproval}
-            approvingUser={approvingUser}
-          />
-
-          {
-            //if logged in user is mod or above, allow adding users to group
-            access < 3 &&
-            (
-              <Grid.Column floated='right' width={6}>
-                <Form size="tiny" onSubmit={this.handleSubmitNewUser}>
-                  <Form.Group className='right'>
-                    <Form.Field>
-                      <Form.Input
-                        placeholder='Add a user'
-                        name='newUser'
-                        value={newUser}
-                        onChange={this.handleChange}
-                        errors={errors["newUser"]}
-                        loading={addUserLoading}
-                      />
-                      {addErrorUser}
-                    </Form.Field>
-                    <Form.Button icon size="tiny" color="blue">
-                      <Icon name="plus" />
-                    </Form.Button>
-                  </Form.Group>
-                  <Form.Group className='right user-access'>
-                    <Picker
-                      onChange={this.handleNewUserRoleChange}
-                      options={[
-                        {key: 0, text: 'Member', value: '3'},
-                        {key: 1, text: 'Moderator', value: '2'},
-                        {key: 2, text: 'Admin', value: '1'}
-                      ]}
-                      label='Role: '
-                      type='role'
-                    />
-                  </Form.Group>
-                </Form>
-              </Grid.Column>
-            )
-          }
+          <Grid stackable>
+            <GroupManageUsers
+              users={users}
+              showModal={this.showModal}
+              deletingUser={deletingUser}
+              access={access}
+              pending={pending}
+              handleApproval={this.handleApproval}
+              approvingUser={approvingUser}
+            />
+            {
+              //if logged in user is mod or above, allow adding users to group
+              access < 3 && (
+                <Grid.Column width={6}>
+                  <Grid.Row>
+                    <Grid.Column>
+                      <Segment.Group>
+                        <Segment>
+                          <Form size="tiny" onSubmit={this.handleSubmitNewUser}>
+                            <Form.Group>
+                              <Form.Field>
+                                <Form.Input
+                                  placeholder='Add a user'
+                                  name='newUser'
+                                  value={newUser}
+                                  onChange={this.handleChange}
+                                  errors={errors["newUser"]}
+                                  loading={addUserLoading}
+                                />
+                                {addErrorUser}
+                              </Form.Field>
+                              <Form.Button icon size="tiny" color="blue">
+                                <Icon name="plus" />
+                              </Form.Button>
+                            </Form.Group>
+                            <Form.Group className='user-access'>
+                              <Picker
+                                onChange={this.handleNewUserRoleChange}
+                                options={[
+                                  {key: 0, text: 'Member', value: '3'},
+                                  {key: 1, text: 'Moderator', value: '2'},
+                                  {key: 2, text: 'Admin', value: '1'}
+                                ]}
+                                label='Role: '
+                                type='role'
+                              />
+                            </Form.Group>
+                          </Form>
+                        </Segment>
+                        {
+                          access < 1 && (
+                          <Segment>
+                            <Label size='large' basic color='orange'>
+                              {'Transfer Ownership'}
+                            </Label>
+                            <p />
+                            <p>
+                              {`WARNING: By transfering the ownership of community group`}
+                              {' '}
+                              <strong>
+                                {`'${groupName}'`}
+                              </strong>
+                              {' '}
+                              {`to someone else, you will no longer be the owner.`}
+                            </p>
+                            <Form size="tiny" onSubmit={this.handleSubmitChangeOwner}>
+                              <Form.Group>
+                                <Form.Field>
+                                  <Form.Input
+                                    placeholder='New owner'
+                                    name='newOwner'
+                                    value={newOwner}
+                                    onChange={this.handleChange}
+                                    errors={errors['newOwner']}
+                                    loading={newOwnerLoading}
+                                  />
+                                  {addErrorOwner}
+                                </Form.Field>
+                                <Form.Button icon size="tiny" color="orange">
+                                  {'Transfer'}
+                                </Form.Button>
+                              </Form.Group>
+                            </Form>
+                          </Segment>
+                          )
+                        }
+                      </Segment.Group>
+                    </Grid.Column>
+                  </Grid.Row>
+                </Grid.Column>
+              )
+            }
+          </Grid>
         </Grid.Row>
 
         <Divider className='section' />

--- a/client/src/components/pages/Manage/GroupManagePending.js
+++ b/client/src/components/pages/Manage/GroupManagePending.js
@@ -51,9 +51,9 @@ const GroupManagePending = ({pending, handleApproval, approvingUser}) => (
                           ? <Dimmer inverted active><Loader /></Dimmer>
                           : ''
                       }
-                      <a href={`/approve/${u.user}/`} onClick={e => handleApproval(e, u.user, 'approve')}><Icon name='plus' color='blue' /></a>
+                      <a href={`/approve/${u.user}/`} onClick={e => handleApproval(e, u.user, 'approve')}><Icon name='plus' color='green' /></a>
                       {' / '}
-                      <a href={`/deny/${u.user}/`} onClick={e => handleApproval(e, u.user, 'deny')}><Icon name='delete' color='blue' /></a>
+                      <a href={`/deny/${u.user}/`} onClick={e => handleApproval(e, u.user, 'deny')}><Icon name='delete' color='red' /></a>
                     </Table.Cell>
                   </Table.Row>
                   )

--- a/client/src/components/pages/Manage/GroupsGrid.js
+++ b/client/src/components/pages/Manage/GroupsGrid.js
@@ -16,7 +16,6 @@ import { long, standard } from '../../../utils/dateFormatting';
  *  @param {array} props.groups Array of obejcts for each group to view
  *  @param {bool} props.areGroupsLoading Determines if loading spinner shown
  *  @param {function} props.handleManageGroup Parent function to manage group
- *  @param {bool} props.noOwned Determines if there are no Owned groups
  *  @param {bool} props.isGroupLoading Determines if to show loading spinner
  *  @param {bool} props.selectedGroup Selected group will have spinner
  *  @param {function} props.showModal Sets the modal to be shown or hidden
@@ -28,17 +27,16 @@ const GroupsGrid = (props) => {
     groups,
     handleManageGroup,
     areGroupsLoading,
-    noOwned,
     isGroupLoading,
     selectedGroup,
     showModal,
-    type,
+    section,
     match,
   } = props;
 
   if (areGroupsLoading) {
     return <Loading />;
-  }else if (groups && groups.length && !noOwned) {
+  }else if (groups && groups.length) {
     return (
       <Grid.Row className="content">
         <Grid.Column>
@@ -69,7 +67,7 @@ const GroupsGrid = (props) => {
                             <Icon name='edit' color='blue' />
                           </a>
                           {
-                            type === 'owned' &&
+                            section === 'owned' &&
                             (
                               <a
                                 href={'/group/delete/'+g.name}
@@ -121,8 +119,8 @@ const GroupsGrid = (props) => {
         </Grid.Column>
       </Grid.Row>
     )
-  }else if (noOwned) {
-    const message = (type === 'owned')
+  }else {
+    const message = (section === 'owned')
       ? ("You don't own any community groups. You can create up to 4 community groups.")
       : ("You don't belong to any other communities.")
     return (
@@ -134,16 +132,6 @@ const GroupsGrid = (props) => {
         </Segment>
       </Grid.Column>
     )
-  }else {
-    return (
-      <Grid.Column width={8}>
-        <Segment>
-          <p>
-            {'No community groups exist.'}
-          </p>
-        </Segment>
-      </Grid.Column>
-    )
   }
 }
 
@@ -151,22 +139,20 @@ GroupsGrid.propTypes = {
   groups: PropTypes.arrayOf(PropTypes.object.isRequired),
   areGroupsLoading: PropTypes.bool,
   handleManageGroup: PropTypes.func,
-  noOwned: PropTypes.bool,
   isGroupLoading: PropTypes.bool,
   selectedGroup: PropTypes.string,
   showModal: PropTypes.func,
-  type: PropTypes.string,
+  section: PropTypes.string,
 };
 
 GroupsGrid.defaultProps = {
   groups: [],
   areGroupsLoading: false,
   handleManageGroup: () => {},
-  noOwned: false,
   isGroupLoading: false,
   selectedGroup: '',
   showModal: () => {},
-  type: '',
+  section: '',
 };
 
 export default GroupsGrid;

--- a/client/src/components/pages/Manage/Manage.css
+++ b/client/src/components/pages/Manage/Manage.css
@@ -23,3 +23,15 @@
 .manage div.meta {
   line-height: 1.5rem;
 }
+
+.manage .blue.delete.icon:hover {
+  color: #db2828 !important;
+}
+
+.manage .green.plus.icon:hover {
+  color: #198f35 !important;
+}
+
+.manage .red.delete.icon:hover {
+  color: #b21e1e !important;
+}

--- a/client/src/components/pages/Manage/Manage.css
+++ b/client/src/components/pages/Manage/Manage.css
@@ -25,13 +25,13 @@
 }
 
 .manage .blue.delete.icon:hover {
-  color: #db2828 !important;
+  color: var(--red) !important;
 }
 
 .manage .green.plus.icon:hover {
-  color: #198f35 !important;
+  color: var(--dark-green) !important;
 }
 
 .manage .red.delete.icon:hover {
-  color: #b21e1e !important;
+  color: var(--dark-red) !important;
 }

--- a/client/src/components/pages/Steem/Post/Comment.css
+++ b/client/src/components/pages/Steem/Post/Comment.css
@@ -92,6 +92,11 @@ ul.commentList > li {
 
 .commentFooter .item a {
   color: var(--charcoal-grey);
+  font-weight: bold;
+}
+
+.commentFooter .item a:hover {
+  color: var(--bright-medium-blue);
 }
 
 .commentFooter .large.icon {
@@ -104,6 +109,10 @@ ul.commentList > li {
 
 .replyForm {
   font-size: 1.1rem;
+  margin-top: 1rem;
+}
+
+.replyForm .ui.buttons {
   margin-top: 1rem;
 }
 

--- a/client/src/components/pages/Steem/Post/Comment.css
+++ b/client/src/components/pages/Steem/Post/Comment.css
@@ -92,7 +92,6 @@ ul.commentList > li {
 
 .commentFooter .item a {
   color: var(--charcoal-grey);
-  font-weight: bold;
 }
 
 .commentFooter .item a:hover {

--- a/client/src/components/pages/Steem/Post/Comment.js
+++ b/client/src/components/pages/Steem/Post/Comment.js
@@ -38,6 +38,7 @@ class Comment extends Component {
     updatedId: PropTypes.number,
     sendDeleteComment: PropTypes.func.isRequired,
     commentDeleting: PropTypes.shape(PropTypes.object.isRequired),
+    isDeleting: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -51,6 +52,7 @@ class Comment extends Component {
     updatedComment: {},
     updatedId: 0,
     commentDeleting: {},
+    isDeleting: false,
   }
 
   state = {

--- a/client/src/components/pages/Steem/Post/Comment.js
+++ b/client/src/components/pages/Steem/Post/Comment.js
@@ -35,6 +35,7 @@ class Comment extends Component {
     isUpdating: PropTypes.bool,
     updatedComment: PropTypes.shape(PropTypes.object.isRequired),
     updatedId: PropTypes.number,
+    sendDeleteComment: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -85,7 +86,8 @@ class Comment extends Component {
   }
 
   /**
-   *  TODO: Show the edit form and allow a post to be edited and saved.
+   *  When the 'Edit' link is clicked for a comment, this runs to change the
+   * state of the 'showEditForm' var to toogle showing/hiding the edit form.
    */
   onShowEditForm = (e) => {
     e.preventDefault();
@@ -133,6 +135,7 @@ class Comment extends Component {
         isUpdating,
         updatedComment,
         updatedId,
+        sendDeleteComment,
       }
     } = this;
 
@@ -197,7 +200,8 @@ class Comment extends Component {
         />
       )
       : null;
-
+console.log('props',this.props)
+console.log('state',this.state)
     return (
       <React.Fragment>
         <div id={`comment-${id}`} className={`comment depth-${depth}`}>
@@ -250,9 +254,14 @@ class Comment extends Component {
                         }
                         {
                           isAuth && user === author && (
-                            <li className='item'>
-                              <a href='/edit' onClick={this.onShowEditForm}>Edit</a>
-                            </li>
+                            <React.Fragment>
+                              <li className='item'>
+                                <a href='/edit' onClick={this.onShowEditForm}>Edit</a>
+                              </li>
+                              <li className='item'>
+                                <a href='/delete' onClick={e => sendDeleteComment(e, author, permlink)}>Delete</a>
+                              </li>
+                            </React.Fragment>
                           )
                         }
                       </ul>
@@ -289,6 +298,7 @@ class Comment extends Component {
                     isUpdating={isUpdating}
                     updatedComment={updatedComment}
                     updatedId={updatedId}
+                    sendDeleteComment={sendDeleteComment}
                   />
                 </li>
               ))
@@ -319,6 +329,7 @@ class Comment extends Component {
                       isUpdating={isUpdating}
                       updatedComment={updatedComment}
                       updatedId={updatedId}
+                      sendDeleteComment={sendDeleteComment}
                     />
                   </li>
                 ))

--- a/client/src/components/pages/Steem/Post/Comment.js
+++ b/client/src/components/pages/Steem/Post/Comment.js
@@ -200,8 +200,7 @@ class Comment extends Component {
         />
       )
       : null;
-console.log('props',this.props)
-console.log('state',this.state)
+
     return (
       <React.Fragment>
         <div id={`comment-${id}`} className={`comment depth-${depth}`}>

--- a/client/src/components/pages/Steem/Post/Comment.js
+++ b/client/src/components/pages/Steem/Post/Comment.js
@@ -1,5 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
+import { Dimmer, Loader } from "semantic-ui-react";
 
 import ReplyForm from './ReplyForm';
 import Body from './PostBody';
@@ -36,6 +37,7 @@ class Comment extends Component {
     updatedComment: PropTypes.shape(PropTypes.object.isRequired),
     updatedId: PropTypes.number,
     sendDeleteComment: PropTypes.func.isRequired,
+    commentDeleting: PropTypes.shape(PropTypes.object.isRequired),
   };
 
   static defaultProps = {
@@ -48,6 +50,7 @@ class Comment extends Component {
     isUpdating: false,
     updatedComment: {},
     updatedId: 0,
+    commentDeleting: {},
   }
 
   state = {
@@ -136,6 +139,8 @@ class Comment extends Component {
         updatedComment,
         updatedId,
         sendDeleteComment,
+        commentDeleting,
+        isDeleting,
       }
     } = this;
 
@@ -204,6 +209,9 @@ class Comment extends Component {
     return (
       <React.Fragment>
         <div id={`comment-${id}`} className={`comment depth-${depth}`}>
+          {
+            isDeleting && hasLength(commentDeleting) && commentDeleting.author === author && commentDeleting.permlink === permlink && <Dimmer inverted active={isDeleting}><Loader /></Dimmer>
+          }
           <ul className='commentList'>
             <li className='commentAvatar'>
               <Avatar author={author} height='40px' width='40px' />
@@ -257,9 +265,13 @@ class Comment extends Component {
                               <li className='item'>
                                 <a href='/edit' onClick={this.onShowEditForm}>Edit</a>
                               </li>
-                              <li className='item'>
-                                <a href='/delete' onClick={e => sendDeleteComment(e, author, permlink)}>Delete</a>
-                              </li>
+                              {
+                                comment.children < 1 && (
+                                  <li className='item'>
+                                    <a href='/delete' onClick={e => sendDeleteComment(e, author, permlink, commentPayload)}>Delete</a>
+                                  </li>
+                                )
+                              }
                             </React.Fragment>
                           )
                         }
@@ -298,6 +310,8 @@ class Comment extends Component {
                     updatedComment={updatedComment}
                     updatedId={updatedId}
                     sendDeleteComment={sendDeleteComment}
+                    commentDeleting={commentDeleting}
+                    isDeleting={isDeleting}
                   />
                 </li>
               ))
@@ -310,7 +324,7 @@ class Comment extends Component {
           && (
             <ul className={replyClass}>
               {
-                sortComments(commentPayload[id], 'new').map(reply => (
+                sortComments(commentPayload[id], sortBy).map(reply => (
                   <li className='commentReply' key={reply.id}>
                     <Comment
                       comment={reply}
@@ -329,6 +343,8 @@ class Comment extends Component {
                       updatedComment={updatedComment}
                       updatedId={updatedId}
                       sendDeleteComment={sendDeleteComment}
+                      commentDeleting={commentDeleting}
+                      isDeleting={isDeleting}
                     />
                   </li>
                 ))

--- a/client/src/components/pages/Steem/Post/Comment.js
+++ b/client/src/components/pages/Steem/Post/Comment.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import { Dimmer, Loader } from "semantic-ui-react";
+import { Dimmer, Loader, Popup, Button } from "semantic-ui-react";
 
 import ReplyForm from './ReplyForm';
 import Body from './PostBody';
@@ -269,9 +269,23 @@ class Comment extends Component {
                               </li>
                               {
                                 comment.children < 1 && (
-                                  <li className='item'>
-                                    <a href='/delete' onClick={e => sendDeleteComment(e, author, permlink, commentPayload)}>Delete</a>
-                                  </li>
+                                  <Popup
+                                    trigger={(
+                                      <li className='item'>
+                                        <a href='/delete' onClick={e => e.preventDefault()}>Delete</a>
+                                      </li>
+                                    )}
+                                    position='top left'
+                                    flowing
+                                    hoverable
+                                    on='click'
+                                  >
+                                    <Button
+                                      color='red'
+                                      content='Confirm delete.'
+                                      onClick={e => sendDeleteComment(e, author, permlink, commentPayload)}
+                                    />
+                                  </Popup>
                                 )
                               }
                             </React.Fragment>

--- a/client/src/components/pages/Steem/Post/Comments.js
+++ b/client/src/components/pages/Steem/Post/Comments.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { hasLength, getUpvotes, sumPayout } from '../../../../utils/helpers';
-import { deleteComment } from '../../../../actions/sendCommentActions';
+import { deleteComment } from '../../../../actions/commentsActions';
 import Comment from './Comment';
 import './Comments.css';
 
@@ -53,12 +53,6 @@ const sortComments = (comments, sortBy) => {
   }
 }
 
-const handleDeleteComment = (e, author, permlink) => {
-  e.preventDefault();
-  const { sendDeleteComment } = this.props;
-  sendDeleteComment(author, permlink);
-}
-
 /**
  *  Comments container to process the first root level of comments of a post.
  *  Additionally, any new comments in `commentPayload` at the root level of
@@ -85,7 +79,15 @@ const Comments = (props) => {
     isUpdating,
     updatedComment,
     updatedId,
+    commentDeleting,
+    isDeleting,
   } = props;
+
+  const handleDeleteComment = (e, author, permlink, commentPayload) => {
+    e.preventDefault();
+    const { sendDeleteComment } = props;
+    sendDeleteComment(author, permlink, commentPayload);
+  }
 
   return (
     <React.Fragment>
@@ -110,6 +112,8 @@ const Comments = (props) => {
                 updatedComment={updatedComment}
                 updatedId={updatedId}
                 sendDeleteComment={handleDeleteComment}
+                commentDeleting={commentDeleting}
+                isDeleting={isDeleting}
               />
             </li>
           ))
@@ -135,6 +139,8 @@ const Comments = (props) => {
                 updatedComment={updatedComment}
                 updatedId={updatedId}
                 sendDeleteComment={handleDeleteComment}
+                commentDeleting={commentDeleting}
+                isDeleting={isDeleting}
               />
             </li>
           ))
@@ -187,6 +193,8 @@ Comments.defaultProps = {
        isUpdating,
        updatedComment,
        updatedId,
+       isDeleting,
+       commentDeleting,
      },
    } = state;
 
@@ -195,6 +203,8 @@ Comments.defaultProps = {
      isUpdating,
      updatedComment,
      updatedId,
+     isDeleting,
+     commentDeleting,
    }
  }
 
@@ -206,8 +216,8 @@ Comments.defaultProps = {
   */
  const mapDispatchToProps = dispatch => (
   {
-    sendDeleteComment: (author, permlink) => (
-      dispatch(deleteComment(author, permlink))
+    sendDeleteComment: (author, permlink, commentPayload) => (
+      dispatch(deleteComment(author, permlink, commentPayload))
     ),
   }
  );

--- a/client/src/components/pages/Steem/Post/Comments.js
+++ b/client/src/components/pages/Steem/Post/Comments.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { hasLength, getUpvotes, sumPayout } from '../../../../utils/helpers';
+import { deleteComment } from '../../../../actions/sendCommentActions';
 import Comment from './Comment';
 import './Comments.css';
 
@@ -50,6 +51,12 @@ const sortComments = (comments, sortBy) => {
     default:
       return comments;
   }
+}
+
+const handleDeleteComment = (e, author, permlink) => {
+  e.preventDefault();
+  const { sendDeleteComment } = this.props;
+  sendDeleteComment(author, permlink);
 }
 
 /**
@@ -102,6 +109,7 @@ const Comments = (props) => {
                 isUpdating={isUpdating}
                 updatedComment={updatedComment}
                 updatedId={updatedId}
+                sendDeleteComment={handleDeleteComment}
               />
             </li>
           ))
@@ -126,6 +134,7 @@ const Comments = (props) => {
                 isUpdating={isUpdating}
                 updatedComment={updatedComment}
                 updatedId={updatedId}
+                sendDeleteComment={handleDeleteComment}
               />
             </li>
           ))
@@ -151,6 +160,7 @@ Comments.propTypes = {
   isUpdating: PropTypes.bool,
   updatedComment: PropTypes.shape(PropTypes.object.isRequired),
   updatedId: PropTypes.number,
+  sendDeleteComment: PropTypes.func.isRequired,
 };
 
 Comments.defaultProps = {
@@ -188,5 +198,18 @@ Comments.defaultProps = {
    }
  }
 
-export default connect(mapStateToProps)(Comments);
-//export default Comments;
+ /**
+  *  Map redux dispatch functions to component props.
+  *
+  *  @param {object} dispatch - Redux dispatch
+  *  @returns {object} - Object with recent activity data
+  */
+ const mapDispatchToProps = dispatch => (
+  {
+    sendDeleteComment: (author, permlink) => (
+      dispatch(deleteComment(author, permlink))
+    ),
+  }
+ );
+
+export default connect(mapStateToProps, mapDispatchToProps)(Comments);

--- a/client/src/components/pages/Steem/Post/Comments.js
+++ b/client/src/components/pages/Steem/Post/Comments.js
@@ -167,6 +167,8 @@ Comments.propTypes = {
   updatedComment: PropTypes.shape(PropTypes.object.isRequired),
   updatedId: PropTypes.number,
   sendDeleteComment: PropTypes.func.isRequired,
+  commentDeleting: PropTypes.shape(PropTypes.object.isRequired),
+  isDeleting: PropTypes.bool,
 };
 
 Comments.defaultProps = {
@@ -178,6 +180,8 @@ Comments.defaultProps = {
   isUpdating: false,
   updatedComment: {},
   updatedId: 0,
+  commentDeleting: {},
+  isDeleting: false,
 }
 
 /**

--- a/client/src/components/pages/Steem/Post/Post.js
+++ b/client/src/components/pages/Steem/Post/Post.js
@@ -7,7 +7,7 @@ import PostDetails from './PostDetails';
 import ErrorBoundary from '../../../ErrorBoundary/ErrorBoundary';
 import ModalGroup from '../../../Modal/ModalGroup';
 import ErrorLabel from '../../../ErrorLabel/ErrorLabel';
-import { getDetailsContent } from '../../../../actions/detailsPostActions';
+import { getDetailsContent, clearPost } from '../../../../actions/detailsPostActions';
 import * as addPostActions from '../../../../actions/addPostActions';
 import { upvotePost } from '../../../../actions/upvoteActions';
 import { sendComment } from '../../../../actions/sendCommentActions';
@@ -69,6 +69,7 @@ class Post extends Component {
     super(props);
 
     this.existPost = "Post already in group.";
+    this.redirect = '';
   }
 
   /**
@@ -99,6 +100,8 @@ class Post extends Component {
     const {
       getContent,
       draft,
+      redirect,
+      clearPostData,
       match: {
         params: {
           author,
@@ -107,8 +110,15 @@ class Post extends Component {
       }
     } = this.props;
 
+    this.redirect = '';
+
     if (!hasLength(draft) && draft !== prevProps.draft) {
       getContent(author, permlink);
+    }
+
+    if (redirect && redirect !== prevProps.redirect) {
+      this.redirect = redirect;
+      clearPostData();
     }
   }
 
@@ -138,15 +148,14 @@ class Post extends Component {
       commentPayload,
       isUpdating,
       isDeleting,
-      redirect,
     } = this.props;
 
     let addErrorPost = '';
     if (postExists) addErrorPost = <ErrorLabel position='left' text={this.existPost} />;
 
     return (
-      redirect
-      ? <Redirect to={redirect} />
+      this.redirect
+      ? <Redirect to={this.redirect} />
       : (
         <ErrorBoundary>
           <React.Fragment>
@@ -295,6 +304,9 @@ const mapDispatchToProps = dispatch => (
     sendComment: (body, parentPost) => (
       dispatch(sendComment(body, parentPost))
     ),
+    clearPostData: () => (
+      dispatch(clearPost())
+    ),clearPost
   }
 );
 

--- a/client/src/components/pages/Steem/Post/Post.js
+++ b/client/src/components/pages/Steem/Post/Post.js
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { Redirect } from 'react-router-dom';
 
 import PostDetails from './PostDetails';
 import ErrorBoundary from '../../../ErrorBoundary/ErrorBoundary';
@@ -45,7 +46,8 @@ class Post extends Component {
     isFetchingDetails: PropTypes.bool.isRequired,
     isUpdating: PropTypes.bool,
     draft: PropTypes.shape(PropTypes.object.isRequired),
-    updatedId: PropTypes.number,
+    isDeleting: PropTypes.bool,
+    redirect: PropTypes.string,
   };
 
   static defaultProps = {
@@ -59,7 +61,8 @@ class Post extends Component {
     replies: [],
     isUpdating: false,
     draft: {},
-    updatedId: 0,
+    isDeleting: false,
+    redirect: '',
   }
 
   constructor(props) {
@@ -134,52 +137,59 @@ class Post extends Component {
       commentedId,
       commentPayload,
       isUpdating,
+      isDeleting,
+      redirect,
     } = this.props;
 
     let addErrorPost = '';
     if (postExists) addErrorPost = <ErrorLabel position='left' text={this.existPost} />;
 
     return (
-      <ErrorBoundary>
-        <React.Fragment>
-          <ModalGroup
-            modalOpen={modalOpenAddPost}
-            onModalClose={onModalCloseAddPost}
-            handleModalClick={handleModalClickAddPost}
-            handleGroupSelect={handleGroupSelect}
-            groups={groups}
-            addErrorPost={addErrorPost}
-            addPostLoading={addPostLoading}
-          />
-          {
-            !isFetchingDetails && !hasLength(post)
-            ? <div>That post does not exist.</div>
-            : !isFetchingDetails && hasLength(post)
-              ? (
-                <PostDetails
-                  match={match}
-                  showModal={showModal}
-                  user={user}
-                  csrf={csrf}
-                  isAuth={isAuth}
-                  getContent={getContent}
-                  post={post}
-                  handleUpvote={handleUpvote}
-                  upvotePayload={upvotePayload}
-                  replies={replies}
-                  sendComment={sendComment}
-                  isCommenting={isCommenting}
-                  commentedId={commentedId}
-                  isFetching={isFetchingDetails}
-                  commentPayload={commentPayload}
-                  isUpdating={isUpdating}
-                />
-              )
-              :  <Loading />
+      redirect
+      ? <Redirect to={redirect} />
+      : (
+        <ErrorBoundary>
+          <React.Fragment>
+            <ModalGroup
+              modalOpen={modalOpenAddPost}
+              onModalClose={onModalCloseAddPost}
+              handleModalClick={handleModalClickAddPost}
+              handleGroupSelect={handleGroupSelect}
+              groups={groups}
+              addErrorPost={addErrorPost}
+              addPostLoading={addPostLoading}
+            />
+            {
+              !isFetchingDetails && !hasLength(post)
+              ? <div>That post does not exist.</div>
+              : !isFetchingDetails && hasLength(post)
+                ? (
+                  <PostDetails
+                    match={match}
+                    showModal={showModal}
+                    user={user}
+                    csrf={csrf}
+                    isAuth={isAuth}
+                    getContent={getContent}
+                    post={post}
+                    handleUpvote={handleUpvote}
+                    upvotePayload={upvotePayload}
+                    replies={replies}
+                    sendComment={sendComment}
+                    isCommenting={isCommenting}
+                    commentedId={commentedId}
+                    isFetching={isFetchingDetails}
+                    commentPayload={commentPayload}
+                    isUpdating={isUpdating}
+                    isDeleting={isDeleting}
+                  />
+                )
+                :  <Loading />
 
-          }
-        </React.Fragment>
-      </ErrorBoundary>
+            }
+          </React.Fragment>
+        </ErrorBoundary>
+      )
     )
   }
 }
@@ -200,6 +210,8 @@ class Post extends Component {
      detailsPost: {
        isFetchingDetails,
        post,
+       isDeleting,
+       redirect,
      },
      userGroups: {
        groups,
@@ -249,6 +261,8 @@ class Post extends Component {
      editingComment,
      isUpdating,
      draft,
+     isDeleting,
+     redirect,
    }
  }
 

--- a/client/src/components/pages/Steem/Post/Post.js
+++ b/client/src/components/pages/Steem/Post/Post.js
@@ -10,7 +10,7 @@ import { getDetailsContent } from '../../../../actions/detailsPostActions';
 import * as addPostActions from '../../../../actions/addPostActions';
 import { upvotePost } from '../../../../actions/upvoteActions';
 import { sendComment } from '../../../../actions/sendCommentActions';
-import {hasLength} from '../../../../utils/helpers';
+import { hasLength } from '../../../../utils/helpers';
 import Loading from '../../../Loading/Loading';
 
 /**
@@ -43,6 +43,9 @@ class Post extends Component {
     onModalCloseAddPost: PropTypes.func.isRequired,
     handleGroupSelect: PropTypes.func.isRequired,
     isFetchingDetails: PropTypes.bool.isRequired,
+    isUpdating: PropTypes.bool,
+    draft: PropTypes.shape(PropTypes.object.isRequired),
+    updatedId: PropTypes.number,
   };
 
   static defaultProps = {
@@ -54,6 +57,9 @@ class Post extends Component {
     match: {},
     csrf: '',
     replies: [],
+    isUpdating: false,
+    draft: {},
+    updatedId: 0,
   }
 
   constructor(props) {
@@ -80,6 +86,29 @@ class Post extends Component {
     getContent(author, permlink);
   }
 
+  /**
+   *  This is needed to pull new data from a post after an update is done.
+   *  Rather than simpy upadte the title, body and tags alone from the draft
+   *  update, the time elapsed could contain new comments or upvotes that
+   *  are usefult o see after an update, and one might expect to see.
+   */
+  componentDidUpdate(prevProps) {
+    const {
+      getContent,
+      draft,
+      match: {
+        params: {
+          author,
+          permlink
+        }
+      }
+    } = this.props;
+
+    if (!hasLength(draft) && draft !== prevProps.draft) {
+      getContent(author, permlink);
+    }
+  }
+
   render() {
     const {
       user,
@@ -104,6 +133,7 @@ class Post extends Component {
       isCommenting,
       commentedId,
       commentPayload,
+      isUpdating,
     } = this.props;
 
     let addErrorPost = '';
@@ -142,6 +172,7 @@ class Post extends Component {
                   commentedId={commentedId}
                   isFetching={isFetchingDetails}
                   commentPayload={commentPayload}
+                  isUpdating={isUpdating}
                 />
               )
               :  <Loading />
@@ -191,8 +222,11 @@ class Post extends Component {
        commentedId,
        commentPayload,
        editingComment,
-       isUpdating,
      },
+     sendPost: {
+       isUpdating,
+       draft,
+     }
    } = state;
 
    return {
@@ -214,6 +248,7 @@ class Post extends Component {
      commentPayload,
      editingComment,
      isUpdating,
+     draft,
    }
  }
 

--- a/client/src/components/pages/Steem/Post/Post.js
+++ b/client/src/components/pages/Steem/Post/Post.js
@@ -48,6 +48,7 @@ class Post extends Component {
     draft: PropTypes.shape(PropTypes.object.isRequired),
     isDeleting: PropTypes.bool,
     redirect: PropTypes.string,
+    clearPostData: PropTypes.func,
   };
 
   static defaultProps = {
@@ -63,6 +64,7 @@ class Post extends Component {
     draft: {},
     isDeleting: false,
     redirect: '',
+    clearPostData: () => {},
   }
 
   constructor(props) {

--- a/client/src/components/pages/Steem/Post/Post.js
+++ b/client/src/components/pages/Steem/Post/Post.js
@@ -88,7 +88,7 @@ class Post extends Component {
 
   /**
    *  This is needed to pull new data from a post after an update is done.
-   *  Rather than simpy upadte the title, body and tags alone from the draft
+   *  Rather than simpy update the title, body and tags alone from the draft
    *  update, the time elapsed could contain new comments or upvotes that
    *  are usefult o see after an update, and one might expect to see.
    */

--- a/client/src/components/pages/Steem/Post/PostBody.css
+++ b/client/src/components/pages/Steem/Post/PostBody.css
@@ -1,7 +1,7 @@
 @import '../../../../variables.css';
 
 .Body {
-  font-size: 1.3rem;
+  font-size: 1.37rem;
   overflow-wrap: break-word;
 }
 

--- a/client/src/components/pages/Steem/Post/PostDetails.js
+++ b/client/src/components/pages/Steem/Post/PostDetails.js
@@ -21,6 +21,7 @@ import { sumPayout } from '../../../../utils/helpers';
 import { editPost, deletePost } from '../../../../actions/sendPostActions';
 import { clearPost } from '../../../../actions/detailsPostActions';
 import { commentsClear } from '../../../../actions/commentsActions';
+import { sendCommentClear } from '../../../../actions/sendCommentActions';
 
 import './PostDetails.css'
 
@@ -80,9 +81,10 @@ class PostDetails extends Component {
   }
 
   componentWillUnmount() {
-    const { clearPostDetails, clearComments } = this.props;
+    const { clearPostDetails, clearComments, clearNewComments } = this.props;
     clearPostDetails();
     clearComments();
+    clearNewComments();
   }
 
   /**
@@ -389,6 +391,9 @@ const mapDispatchToProps = dispatch => (
    ),
    clearComments: () => (
      dispatch(commentsClear())
+   ),
+   clearNewComments: () => (
+     dispatch(sendCommentClear())
    ),
  }
 );

--- a/client/src/components/pages/Steem/Post/PostDetails.js
+++ b/client/src/components/pages/Steem/Post/PostDetails.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import { Grid, Form, Select } from "semantic-ui-react";
+import { Grid, Form, Select, Dimmer, Loader } from "semantic-ui-react";
 import { attempt, isError, has, get } from 'lodash';
 import { Helmet, HelmetProvider } from 'react-helmet-async';
 import { connect } from 'react-redux';
@@ -18,8 +18,8 @@ import AuthorCatgoryTime from '../AuthorCatgoryTime';
 import PostActions from '../PostActions';
 import Loading from '../../../Loading/Loading';
 import { sumPayout } from '../../../../utils/helpers';
-import { editPost, deletePost } from '../../../../actions/sendPostActions';
-import { clearPost } from '../../../../actions/detailsPostActions';
+import { editPost } from '../../../../actions/sendPostActions';
+import { clearPost, deletePost } from '../../../../actions/detailsPostActions';
 import { commentsClear } from '../../../../actions/commentsActions';
 import { sendCommentClear } from '../../../../actions/sendCommentActions';
 
@@ -48,6 +48,7 @@ class PostDetails extends Component {
     clearPostDetails: PropTypes.func,
     sendDeletePost: PropTypes.func,
     clearComments: PropTypes.func,
+    isDeleting: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -62,6 +63,7 @@ class PostDetails extends Component {
     clearPostDetails: () => {},
     sendDeletePost: () => {},
     clearComments: () => {},
+    isDeleting: false,
   }
 
   constructor(props) {
@@ -168,6 +170,7 @@ class PostDetails extends Component {
       commentedId,
       commentPayload,
       isUpdating,
+      isDeleting,
     } = this.props;
 
     const {
@@ -230,6 +233,9 @@ class PostDetails extends Component {
             <meta property="article:published_time" content={new Date(created).toDateString()} />
           </Helmet>
           <Grid verticalAlign='middle' columns={1} centered>
+            {
+              isDeleting && <Dimmer inverted active={isDeleting}><Loader /></Dimmer>
+            }
             <Grid.Row>
               <Grid.Column width={columns}>
                 <React.Fragment>

--- a/client/src/components/pages/Steem/Post/PostDetails.js
+++ b/client/src/components/pages/Steem/Post/PostDetails.js
@@ -20,6 +20,7 @@ import Loading from '../../../Loading/Loading';
 import { sumPayout } from '../../../../utils/helpers';
 import { editPost, deletePost } from '../../../../actions/sendPostActions';
 import { clearPost } from '../../../../actions/detailsPostActions';
+import { commentsClear } from '../../../../actions/commentsActions';
 
 import './PostDetails.css'
 
@@ -45,6 +46,7 @@ class PostDetails extends Component {
     showEditPost: PropTypes.func,
     clearPostDetails: PropTypes.func,
     sendDeletePost: PropTypes.func,
+    clearComments: PropTypes.func,
   };
 
   static defaultProps = {
@@ -58,6 +60,7 @@ class PostDetails extends Component {
     showEditPost: () => {},
     clearPostDetails: () => {},
     sendDeletePost: () => {},
+    clearComments: () => {},
   }
 
   constructor(props) {
@@ -77,13 +80,9 @@ class PostDetails extends Component {
   }
 
   componentWillUnmount() {
-    const { clearPostDetails } = this.props;
+    const { clearPostDetails, clearComments } = this.props;
     clearPostDetails();
-  }
-
-  //Needed to `dangerouslySetInnerHTML`
-  createMarkup = (html) => {
-    return {__html: html};
+    clearComments();
   }
 
   /**
@@ -98,12 +97,24 @@ class PostDetails extends Component {
       });
    }
 
+   /**
+    *  Dispatch to Redux to show the edit post form.
+    *
+    *  @param {event} e Event triggered by element to handle
+    */
    handleEditPost = e => {
      e.preventDefault();
      const { showEditPost, post } = this.props;
      showEditPost(post);
    }
 
+   /**
+    *  Dispatch to Redux to delete the post by author and permlink.
+    *
+    *  @param {event} e Event triggered by element to handle
+    *  @param {string} author Author of post
+    *  @param {string} permlink Permlink of post
+    */
    handleDeletePost = (e, author, permlink) => {
      e.preventDefault();
      const { sendDeletePost } = this.props;
@@ -360,24 +371,6 @@ class PostDetails extends Component {
 }
 
 /**
- *  Map redux state to component props.
- *
- *  @param {object} state - Redux state
- *  @returns {object} - Object with recent activity data
- */
- const mapStateToProps = state => {
-   const {
-     sendPost: {
-       isUpdating,
-     }
-   } = state;
-
-   return {
-     isUpdating,
-   }
- }
-
-/**
  *  Map redux dispatch functions to component props.
  *
  *  @param {object} dispatch - Redux dispatch
@@ -394,7 +387,10 @@ const mapDispatchToProps = dispatch => (
    sendDeletePost: (author, permlink) => (
      dispatch(deletePost(author, permlink))
    ),
+   clearComments: () => (
+     dispatch(commentsClear())
+   ),
  }
 );
 
-export default connect(mapStateToProps, mapDispatchToProps)(PostDetails);
+export default connect(null, mapDispatchToProps)(PostDetails);

--- a/client/src/components/pages/Steem/Post/PostDetails.js
+++ b/client/src/components/pages/Steem/Post/PostDetails.js
@@ -18,8 +18,9 @@ import AuthorCatgoryTime from '../AuthorCatgoryTime';
 import PostActions from '../PostActions';
 import Loading from '../../../Loading/Loading';
 import { sumPayout } from '../../../../utils/helpers';
-import { editPost } from '../../../../actions/sendPostActions';
+import { editPost, deletePost } from '../../../../actions/sendPostActions';
 import { clearPost } from '../../../../actions/detailsPostActions';
+
 import './PostDetails.css'
 
 /**
@@ -43,6 +44,7 @@ class PostDetails extends Component {
     isUpdating: PropTypes.bool,
     showEditPost: PropTypes.func,
     clearPostDetails: PropTypes.func,
+    sendDeletePost: PropTypes.func,
   };
 
   static defaultProps = {
@@ -55,6 +57,7 @@ class PostDetails extends Component {
     isUpdating: false,
     showEditPost: () => {},
     clearPostDetails: () => {},
+    sendDeletePost: () => {},
   }
 
   constructor(props) {
@@ -99,6 +102,12 @@ class PostDetails extends Component {
      e.preventDefault();
      const { showEditPost, post } = this.props;
      showEditPost(post);
+   }
+
+   handleDeletePost = (e, author, permlink) => {
+     e.preventDefault();
+     const { sendDeletePost } = this.props;
+     sendDeletePost(author, permlink);
    }
 
   /**
@@ -284,6 +293,7 @@ class PostDetails extends Component {
                                 image={image}
                                 isPost
                                 onEditPost={this.handleEditPost}
+                                onDeletePost={this.handleDeletePost}
                               />
                             </div>
                             <hr />
@@ -378,9 +388,12 @@ const mapDispatchToProps = dispatch => (
    showEditPost: (post) => (
      dispatch(editPost(post))
    ),
-   clearPostDetails: () => {
+   clearPostDetails: () => (
      dispatch(clearPost())
-   }
+   ),
+   sendDeletePost: (author, permlink) => (
+     dispatch(deletePost(author, permlink))
+   ),
  }
 );
 

--- a/client/src/components/pages/Steem/Post/PostDetails.js
+++ b/client/src/components/pages/Steem/Post/PostDetails.js
@@ -49,6 +49,7 @@ class PostDetails extends Component {
     sendDeletePost: PropTypes.func,
     clearComments: PropTypes.func,
     isDeleting: PropTypes.bool,
+    clearNewComments: PropTypes.func,
   };
 
   static defaultProps = {
@@ -64,6 +65,7 @@ class PostDetails extends Component {
     sendDeletePost: () => {},
     clearComments: () => {},
     isDeleting: false,
+    clearNewComments: () => {},
   }
 
   constructor(props) {

--- a/client/src/components/pages/Steem/Post/ReplyForm.js
+++ b/client/src/components/pages/Steem/Post/ReplyForm.js
@@ -44,18 +44,17 @@ class ReplyForm extends Component {
     body: '',
   }
 
+  //clearBody = false;
+
   /**
    *  If a comment has been posted, clear the form by clearing the body state.
    */
-  static getDerivedStateFromProps(props, state) {
-    if (props.parentPost.id === props.commentedId && !props.isCommenting) {
-      props.toggleReplyForm();
-      return {
-        body: '',
-      };
+  componentDidUpdate(prevProps) {
+    const { isCommenting, parentPost, commentedId, toggleReplyForm } = this.props;
+    if (!isCommenting && isCommenting !== prevProps.isCommenting && parentPost.id === commentedId) {
+      toggleReplyForm();
+      this.handleClearReply();
     }
-
-    return null;
   }
 
   /**
@@ -151,7 +150,7 @@ class ReplyForm extends Component {
                 onChange={this.handleChange}
                 name='body'
                 value={body || commentBody}
-                disabled={disabled}
+                disabled={isCommenting}
               />
               <div>
                 <Button

--- a/client/src/components/pages/Steem/Post/ReplyForm.js
+++ b/client/src/components/pages/Steem/Post/ReplyForm.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Form, TextArea, Button, Dimmer, Loader } from "semantic-ui-react";
+import { Form, TextArea, Button, Dimmer, Loader, Icon } from "semantic-ui-react";
 
 import { editComment } from '../../../../actions/sendCommentActions';
 
@@ -124,7 +124,7 @@ class ReplyForm extends Component {
     } = this;
 
     let cancelButtonClick = ['Clear', this.handleClearReply];
-    let submitButtonClick = ['Post', this.handleSendComment];
+    let submitButtonClick = ['Reply', this.handleSendComment];
     let disabled = body === '' || isCommenting;
     if (commentBody) {
       submitButtonClick = ['Update', this.handleEditComment];
@@ -152,22 +152,25 @@ class ReplyForm extends Component {
                 value={body || commentBody}
                 disabled={isCommenting}
               />
-              <div>
+              <Button.Group>
                 <Button
-                  size="large"
-                  color="blue"
-                  content={submitButtonClick[0]}
+                  animated='vertical'
+                  color='blue'
                   disabled={disabled}
                   onClick={submitButtonClick[1]}
-                />
+                >
+                  <Button.Content hidden>{submitButtonClick[0]}</Button.Content>
+                  <Button.Content visible>
+                    <Icon name='reply' />
+                  </Button.Content>
+                </Button>
                 <Button
-                  size="large"
                   color="grey"
                   content={cancelButtonClick[0]}
                   disabled={disabled}
                   onClick={cancelButtonClick[1]}
                 />
-              </div>
+              </Button.Group>
 
             </Form>
             {

--- a/client/src/components/pages/Steem/Post/ReplyForm.js
+++ b/client/src/components/pages/Steem/Post/ReplyForm.js
@@ -164,12 +164,17 @@ class ReplyForm extends Component {
                     <Icon name='reply' />
                   </Button.Content>
                 </Button>
+
                 <Button
-                  color="grey"
-                  content={cancelButtonClick[0]}
+                  animated='vertical'
                   disabled={disabled}
                   onClick={cancelButtonClick[1]}
-                />
+                >
+                  <Button.Content hidden>{cancelButtonClick[0]}</Button.Content>
+                  <Button.Content visible>
+                    <Icon name='eraser' />
+                  </Button.Content>
+                </Button>
               </Button.Group>
 
             </Form>

--- a/client/src/components/pages/Steem/PostActions.css
+++ b/client/src/components/pages/Steem/PostActions.css
@@ -79,3 +79,10 @@
   margin-left:2rem;
   border-left: none;
 }
+
+.ui.animated.button {
+  padding: 6px 11px;
+}
+.ui.animated.button .visible.content {
+  margin-right: 5px;
+}

--- a/client/src/components/pages/Steem/PostActions.css
+++ b/client/src/components/pages/Steem/PostActions.css
@@ -95,9 +95,9 @@
 }
 
 .ui.blue.button.actionAdd:hover {
-  background-color: #21ba45 !important;
+  background-color: var(--green) !important;
 }
 
 .ui.blue.button.actionDelete:hover {
-  background-color: #db2828 !important;
+  background-color: var(--red) !important;
 }

--- a/client/src/components/pages/Steem/PostActions.css
+++ b/client/src/components/pages/Steem/PostActions.css
@@ -80,11 +80,18 @@
   border-left: none;
 }
 
-.ui.animated.button {
+.post-actions .ui.animated.button {
   padding: 6px 11px;
 }
-.ui.animated.button .visible.content {
+.post-actions .ui.animated.button .visible.content {
   margin-right: 5px;
+}
+
+.ui.blue.button.actionAdd .visible.content {
+  margin-right: 0.5rem;
+}
+.ui.blue.button.actionEdit .visible.content {
+  margin-right: 0.5rem;
 }
 
 .ui.blue.button.actionAdd:hover {

--- a/client/src/components/pages/Steem/PostActions.css
+++ b/client/src/components/pages/Steem/PostActions.css
@@ -98,10 +98,6 @@
   background-color: #21ba45 !important;
 }
 
-.ui.blue.button.actionEdit:hover {
-  background-color: orange !important;
-}
-
 .ui.blue.button.actionDelete:hover {
   background-color: #db2828 !important;
 }

--- a/client/src/components/pages/Steem/PostActions.css
+++ b/client/src/components/pages/Steem/PostActions.css
@@ -86,3 +86,15 @@
 .ui.animated.button .visible.content {
   margin-right: 5px;
 }
+
+.ui.blue.button.actionAdd:hover {
+  background-color: #21ba45 !important;
+}
+
+.ui.blue.button.actionEdit:hover {
+  background-color: orange !important;
+}
+
+.ui.blue.button.actionDelete:hover {
+  background-color: #db2828 !important;
+}

--- a/client/src/components/pages/Steem/PostActions.js
+++ b/client/src/components/pages/Steem/PostActions.js
@@ -89,7 +89,7 @@ class PostActions extends Component {
         image,
         isPost,
         onEditPost,
-        onDeletePost
+        onDeletePost,
       },
     } = this;
 
@@ -140,7 +140,7 @@ class PostActions extends Component {
           {
             user
             && (
-              <React.Fragment>
+              <Button.Group>
                 {
                   isPost && author === user && (
                     <React.Fragment>
@@ -149,23 +149,30 @@ class PostActions extends Component {
                         color='blue'
                         onClick={e => onEditPost(e)}
                         title="Edit post"
+                        className='actionEdit'
                       >
                         <Button.Content hidden>Edit</Button.Content>
                         <Button.Content visible>
                           <Icon name='edit' />
                         </Button.Content>
                       </Button>
-                      <Button
-                        animated='vertical'
-                        color='blue'
-                        onClick={e => onDeletePost(e, author, permlink)}
-                        title="Delete post"
-                      >
-                        <Button.Content hidden>Del</Button.Content>
-                        <Button.Content visible>
-                          <Icon name='remove' />
-                        </Button.Content>
-                      </Button>
+
+                      {
+                        !activeVotes.length && !commentCount && (
+                          <Button
+                            animated='vertical'
+                            color='blue'
+                            onClick={e => onDeletePost(e, author, permlink)}
+                            title="Delete post"
+                            className='actionDelete'
+                          >
+                            <Button.Content hidden>Del</Button.Content>
+                            <Button.Content visible>
+                              <Icon name='remove' />
+                            </Button.Content>
+                          </Button>
+                        )
+                      }
                     </React.Fragment>
                   )
                 }
@@ -174,13 +181,14 @@ class PostActions extends Component {
                   color='blue'
                   onClick={e => showModal(e, 'addPost', {author, category, permlink, title, image})}
                   title="Add to a community"
+                  className='actionAdd'
                 >
                   <Button.Content hidden>Add</Button.Content>
                   <Button.Content visible>
                     <Icon name='plus circle' />
                   </Button.Content>
                 </Button>
-              </React.Fragment>
+              </Button.Group>
             )
           }
         </div>

--- a/client/src/components/pages/Steem/PostActions.js
+++ b/client/src/components/pages/Steem/PostActions.js
@@ -38,6 +38,7 @@ class PostActions extends Component {
     image: PropTypes.string,
     isPost: PropTypes.bool,
     onEditPost: PropTypes.func,
+    onDeletePost: PropTypes.func,
   };
 
   static defaultProps = {
@@ -57,6 +58,7 @@ class PostActions extends Component {
     image: '',
     isPost: false,
     onEditPost: () => {},
+    onDeletePost: () => {},
   };
 
 
@@ -87,6 +89,7 @@ class PostActions extends Component {
         image,
         isPost,
         onEditPost,
+        onDeletePost
       },
     } = this;
 
@@ -140,18 +143,30 @@ class PostActions extends Component {
               <React.Fragment>
                 {
                   isPost && author === user && (
-                    <Button
-                      animated='vertical'
-                      color='blue'
-                      onClick={e => onEditPost(e)}
-                      title="Edit post"
-                    >
-                      <Button.Content hidden>Edit</Button.Content>
-                      <Button.Content visible>
-                        <Icon name='edit' />
-                      </Button.Content>
-                    </Button>
-
+                    <React.Fragment>
+                      <Button
+                        animated='vertical'
+                        color='blue'
+                        onClick={e => onEditPost(e)}
+                        title="Edit post"
+                      >
+                        <Button.Content hidden>Edit</Button.Content>
+                        <Button.Content visible>
+                          <Icon name='edit' />
+                        </Button.Content>
+                      </Button>
+                      <Button
+                        animated='vertical'
+                        color='blue'
+                        onClick={e => onDeletePost(e, author, permlink)}
+                        title="Delete post"
+                      >
+                        <Button.Content hidden>Del</Button.Content>
+                        <Button.Content visible>
+                          <Icon name='remove' />
+                        </Button.Content>
+                      </Button>
+                    </React.Fragment>
                   )
                 }
                 <Button

--- a/client/src/components/pages/Steem/PostActions.js
+++ b/client/src/components/pages/Steem/PostActions.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types'
-import { Icon } from "semantic-ui-react";
+import { Icon, Button } from "semantic-ui-react";
 
 import Vote from './Vote';
 
@@ -140,17 +140,31 @@ class PostActions extends Component {
               <React.Fragment>
                 {
                   isPost && author === user && (
-                    <span>
-                      <a href="/post/edit" onClick={e => onEditPost(e)} title="Edit post">
-                        <Icon name='compose' size='large' />
-                      </a>
-                      {` `}
-                    </span>
+                    <Button
+                      animated='vertical'
+                      color='blue'
+                      onClick={e => onEditPost(e)}
+                      title="Edit post"
+                    >
+                      <Button.Content hidden>Edit</Button.Content>
+                      <Button.Content visible>
+                        <Icon name='edit' />
+                      </Button.Content>
+                    </Button>
+
                   )
                 }
-                <a href="/group/add" onClick={e => showModal(e, 'addPost', {author, category, permlink, title, image})} title="Add to a community">
-                  <Icon name='plus circle' size='large' />
-                </a>
+                <Button
+                  animated='vertical'
+                  color='blue'
+                  onClick={e => showModal(e, 'addPost', {author, category, permlink, title, image})}
+                  title="Add to a community"
+                >
+                  <Button.Content hidden>Add</Button.Content>
+                  <Button.Content visible>
+                    <Icon name='plus circle' />
+                  </Button.Content>
+                </Button>
               </React.Fragment>
             )
           }

--- a/client/src/components/pages/Steem/PostActions.js
+++ b/client/src/components/pages/Steem/PostActions.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types'
-import { Icon, Button } from "semantic-ui-react";
+import { Icon, Button, Popup } from "semantic-ui-react";
 
 import Vote from './Vote';
 
@@ -140,7 +140,7 @@ class PostActions extends Component {
           {
             user
             && (
-              <Button.Group>
+              <div>
                 {
                   isPost && author === user && (
                     <React.Fragment>
@@ -159,18 +159,31 @@ class PostActions extends Component {
 
                       {
                         !activeVotes.length && !commentCount && (
-                          <Button
-                            animated='vertical'
-                            color='blue'
-                            onClick={e => onDeletePost(e, author, permlink)}
-                            title="Delete post"
-                            className='actionDelete'
+                          <Popup
+                            trigger={(
+                              <Button
+                                animated='vertical'
+                                color='blue'
+                                title="Delete post"
+                                className='actionDelete'
+                              >
+                                <Button.Content hidden>Del</Button.Content>
+                                <Button.Content visible>
+                                  <Icon name='remove' />
+                                </Button.Content>
+                              </Button>
+                            )}
+                            position='top left'
+                            flowing
+                            hoverable
+                            on='click'
                           >
-                            <Button.Content hidden>Del</Button.Content>
-                            <Button.Content visible>
-                              <Icon name='remove' />
-                            </Button.Content>
-                          </Button>
+                            <Button
+                              color='red'
+                              content='Confirm delete.'
+                              onClick={e => onDeletePost(e, author, permlink)}
+                            />
+                          </Popup>
                         )
                       }
                     </React.Fragment>
@@ -188,7 +201,7 @@ class PostActions extends Component {
                     <Icon name='plus circle' />
                   </Button.Content>
                 </Button>
-              </Button.Group>
+              </div>
             )
           }
         </div>

--- a/client/src/components/pages/Steem/Posts.js
+++ b/client/src/components/pages/Steem/Posts.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import {Header, Label} from 'semantic-ui-react';
 import { withRouter } from 'react-router-dom';
-//
 
 import PostsSummary from './PostsSummary';
 import ModalGroup from '../../Modal/ModalGroup';
@@ -185,7 +184,7 @@ class Posts extends Component {
 
     let addErrorPost = '';
     if (postExists) addErrorPost = <ErrorLabel position='left' text={this.existPost} />;
-    
+
     return (
       <React.Fragment>
         <ModalGroup

--- a/client/src/components/pages/Steem/Posts.js
+++ b/client/src/components/pages/Steem/Posts.js
@@ -27,7 +27,7 @@ class Posts extends Component {
     user: PropTypes.string,
     csrf: PropTypes.string,
     match: PropTypes.shape(PropTypes.object.isRequired),
-    isFetchingSummary: PropTypes.bool,
+    isFetching: PropTypes.bool,
     hasMore: PropTypes.bool,
     prevPage: PropTypes.string,
     groups: PropTypes.arrayOf(PropTypes.object),
@@ -48,7 +48,7 @@ class Posts extends Component {
   static defaultProps = {
     user: '',
     csrf: '',
-    isFetchingSummary: false,
+    isFetching: false,
     hasMore: true,
     match: {},
     prevPage: '',
@@ -107,8 +107,8 @@ class Posts extends Component {
    *  then calls fetch to get new posts.
    */
   handleScroll = (e) => {
-    const {isFetchingSummary, hasMore} = this.props;
-    if (!isFetchingSummary && hasMore) {
+    const {isFetching, hasMore} = this.props;
+    if (!isFetching && hasMore) {
       var lastLi = document.querySelector("#postList > div.postSummary:last-child");
       var lastLiOffset = lastLi.offsetTop + lastLi.clientHeight;
       var pageOffset = window.pageYOffset + window.innerHeight;
@@ -166,7 +166,7 @@ class Posts extends Component {
         user,
         csrf,
         posts,
-        isFetchingSummary,
+        isFetching,
         prevPage,
         match,
         groups,
@@ -185,7 +185,7 @@ class Posts extends Component {
 
     let addErrorPost = '';
     if (postExists) addErrorPost = <ErrorLabel position='left' text={this.existPost} />;
-
+    
     return (
       <React.Fragment>
         <ModalGroup
@@ -232,7 +232,7 @@ class Posts extends Component {
                       csrf={csrf}
                       handleUpvote={handleUpvote}
                       upvotePayload={upvotePayload}
-                      isFetchingSummary={isFetchingSummary}
+                      isFetching={isFetching}
                     />
                   )
                   : (
@@ -243,7 +243,7 @@ class Posts extends Component {
               </div>
             </div>
             {
-              isFetchingSummary && page === prevPage && <Loading />
+              isFetching && page === prevPage && <Loading />
             }
           </React.Fragment>
         </ErrorBoundary>
@@ -265,7 +265,7 @@ const mapStateToProps = state => {
       csrf,
     },
     summaryPost: {
-      isFetchingSummary,
+      isFetching,
       prevPage,
       hasMore,
       posts,
@@ -288,7 +288,7 @@ const mapStateToProps = state => {
     user,
     csrf,
     posts,
-    isFetchingSummary,
+    isFetching,
     prevPage,
     hasMore,
     groups,

--- a/client/src/components/pages/Steem/Posts.js
+++ b/client/src/components/pages/Steem/Posts.js
@@ -157,7 +157,7 @@ class Posts extends Component {
   handleSubmitFilter = (selectedFilter, tag) => {
     this.selectedFilter = selectedFilter;
     this.tag = tag;
-    this.getPosts('init');
+    this.getPosts('');
   }
 
   render() {

--- a/client/src/components/pages/Steem/PostsSummary.css
+++ b/client/src/components/pages/Steem/PostsSummary.css
@@ -31,10 +31,11 @@
 }
 
 .summary-content h4 {
-  font-size: 1.225rem;
-  line-height: 1.15rem;
+  font-size: 1.25rem;
+  line-height: 1.4rem;
   padding: 0;
   margin-bottom: 0.2rem;
+  font-family: var(--font-content);
 }
 
 .summary-content p {

--- a/client/src/components/pages/Steem/PostsSummary.js
+++ b/client/src/components/pages/Steem/PostsSummary.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import './PostsSummary.css';
 import AuthorCatgoryTime from './AuthorCatgoryTime';
@@ -24,15 +25,14 @@ const PostsSummary = (props) => {
     user,
     handleUpvote,
     upvotePayload,
-    isFetchingSummary,
-    isFetchingScroll
+    isFetching,
   } = props;
 
   let {
     nextPost,
   } = props;
 
-  if (!posts.length && !isFetchingSummary && !isFetchingScroll) {
+  if (!posts.length && !isFetching) {
     return "No Posts";
   }else {
     return (
@@ -136,5 +136,24 @@ const PostsSummary = (props) => {
     )
   }
 }
+
+PostsSummary.propTypes = {
+  posts: PropTypes.arrayOf(PropTypes.object),
+  showModal: PropTypes.func,
+  user: PropTypes.string,
+  handleUpvote: PropTypes.func,
+  upvotePayload: PropTypes.shape(PropTypes.object.isRequired),
+  isFetching: PropTypes.bool,
+};
+
+PostsSummary.defaultProps = {
+  posts: [],
+  showModal: () => {},
+  user: '',
+  handleUpvote: () => {},
+  upvotePayload: {},
+  isFetching: false,
+};
+
 
 export default PostsSummary;

--- a/client/src/components/pages/Steem/Write/Editor.js
+++ b/client/src/components/pages/Steem/Write/Editor.js
@@ -235,8 +235,7 @@ class Write extends Component {
         reset,
       }
     } = this;
-console.log('state',this.state)
-console.log('props',this.props)
+
     return (
       (newPost && !reset)
       ? <Redirect to={newPost} />

--- a/client/src/components/pages/Steem/Write/Editor.js
+++ b/client/src/components/pages/Steem/Write/Editor.js
@@ -6,7 +6,7 @@ import { Redirect } from 'react-router-dom';
 
 import Preview from '../Post/Preview';
 import { createPostMetadata } from '../helpers/postHelpers';
-import { sendPost, clearNewPost, cancelEditPost } from '../../../../actions/sendPostActions';
+import { sendPost, clearSendPost } from '../../../../actions/sendPostActions';
 import './Write.css'
 
 /**
@@ -14,28 +14,27 @@ import './Write.css'
  *  A title field, text area for the post, and tag field are used to generate
  *  the posts for the Steem blockchain.
  */
-class Write extends Component {
+class Editor extends Component {
   static propTypes = {
     user: PropTypes.string,
     createPost: PropTypes.func.isRequired,
-    newPost: PropTypes.string,
+    newPostRedirect: PropTypes.string,
     clearPost: PropTypes.func.isRequired,
     isPosting: PropTypes.bool,
     error: PropTypes.string,
     isUpdating: PropTypes.bool,
     draft: PropTypes.shape(PropTypes.object.isRequired),
-    cancelEdit: PropTypes.func.isRequired,
-    reset: PropTypes.bool,
+    isNewPost: PropTypes.bool,
   };
 
   static defaultProps = {
     user: '',
-    newPost: '',
+    newPostRedirect: '',
     isPosting: false,
     error: '',
     isUpdating: false,
     draft: {},
-    reset: false,
+    isNewPost: false,
   }
 
   constructor(props) {
@@ -49,7 +48,6 @@ class Write extends Component {
       tagErrors: '',
     }
 
-    this.redirect = '';
     this.permlink = '';
     this.rewardOptions = [
       {key: 0, value: '50', text: '50% SBD / 50% STEEM'},
@@ -66,7 +64,7 @@ class Write extends Component {
   componentDidMount() {
     window.scrollTo(0, 0);
 
-    const { clearPost, isUpdating, draft, reset } = this.props;
+    const { clearPost, isUpdating, draft, isNewPost } = this.props;
 
     if (isUpdating && draft) {
       this.permlink = draft.permlink;
@@ -75,7 +73,7 @@ class Write extends Component {
         body: draft.body,
         tags: draft.jsonMetadata.tags.join(' '),
       });
-    }else if (reset) {
+    }else if (isNewPost) {
       clearPost();
       this.setState({
         title: '',
@@ -85,20 +83,9 @@ class Write extends Component {
     }
   }
 
-  /**
-   *  If a post has been posted, redirect to the post.
-   */
-  componentDidUpdate(prevProps) {
-    const { isPosting, newPost } = this.props;
-    if (!isPosting && isPosting !== prevProps.isPosting) {
-      console.log('componentDidUpdate',newPost)
-      this.redirect = (<Redirect to={newPost} />);
-    }
-  }
-
   componentWillUnmount() {
-    const { isUpdating, cancelEdit } = this.props;
-    if (isUpdating) cancelEdit();
+    const { clearPost } = this.props;
+    clearPost();
   }
 
   /**
@@ -152,8 +139,8 @@ class Write extends Component {
 
     this.permlink = '';
 
-    const { isUpdating, cancelEdit } = this.props;
-    if (isUpdating) cancelEdit();
+    const { isUpdating, clearPost } = this.props;
+    if (isUpdating) clearPost();
   }
 
   /**
@@ -239,17 +226,16 @@ class Write extends Component {
       },
       props: {
         isPosting,
-        newPost,
+        isNewPost,
         error,
         isUpdating,
-        reset,
+        newPostRedirect,
       }
     } = this;
-console.log('props',this.props)
-console.log('this.redirect',this.redirect)
+
     return (
-      this.redirect
-      ? this.redirect
+      (newPostRedirect && isNewPost)
+      ? <Redirect to={newPostRedirect} />
       : (
         <div id='write'>
           <Form onSubmit={this.handleSubmit} loading={isPosting}>
@@ -344,7 +330,7 @@ console.log('this.redirect',this.redirect)
      },
      sendPost: {
        isPosting,
-       newPost,
+       newPostRedirect,
        error,
        isUpdating,
        draft,
@@ -354,7 +340,7 @@ console.log('this.redirect',this.redirect)
    return {
      user,
      isPosting,
-     newPost,
+     newPostRedirect,
      error,
      isUpdating,
      draft,
@@ -373,12 +359,9 @@ const mapDispatchToProps = dispatch => (
       dispatch(sendPost(post))
     ),
     clearPost: () => (
-      dispatch(clearNewPost())
-    ),
-    cancelEdit: () => (
-      dispatch(cancelEditPost())
+      dispatch(clearSendPost())
     ),
   }
 );
 
-export default connect(mapStateToProps, mapDispatchToProps)(Write);
+export default connect(mapStateToProps, mapDispatchToProps)(Editor);

--- a/client/src/components/pages/Steem/Write/Editor.js
+++ b/client/src/components/pages/Steem/Write/Editor.js
@@ -49,6 +49,7 @@ class Write extends Component {
       tagErrors: '',
     }
 
+    this.redirect = '';
     this.permlink = '';
     this.rewardOptions = [
       {key: 0, value: '50', text: '50% SBD / 50% STEEM'},
@@ -65,7 +66,7 @@ class Write extends Component {
   componentDidMount() {
     window.scrollTo(0, 0);
 
-    const { newPost, clearPost, isUpdating, draft, reset } = this.props;
+    const { clearPost, isUpdating, draft, reset } = this.props;
 
     if (isUpdating && draft) {
       this.permlink = draft.permlink;
@@ -81,9 +82,18 @@ class Write extends Component {
         body: '',
         tags: '',
       });
-    }/*else if (newPost) {
-      clearPost();
-    }*/
+    }
+  }
+
+  /**
+   *  If a post has been posted, redirect to the post.
+   */
+  componentDidUpdate(prevProps) {
+    const { isPosting, newPost } = this.props;
+    if (!isPosting && isPosting !== prevProps.isPosting) {
+      console.log('componentDidUpdate',newPost)
+      this.redirect = (<Redirect to={newPost} />);
+    }
   }
 
   componentWillUnmount() {
@@ -235,10 +245,11 @@ class Write extends Component {
         reset,
       }
     } = this;
-
+console.log('props',this.props)
+console.log('this.redirect',this.redirect)
     return (
-      (newPost && !reset)
-      ? <Redirect to={newPost} />
+      this.redirect
+      ? this.redirect
       : (
         <div id='write'>
           <Form onSubmit={this.handleSubmit} loading={isPosting}>

--- a/client/src/components/pages/Steem/Write/Editor.js
+++ b/client/src/components/pages/Steem/Write/Editor.js
@@ -49,7 +49,6 @@ class Write extends Component {
       tagErrors: '',
     }
 
-    this.redirect = '';
     this.permlink = '';
     this.rewardOptions = [
       {key: 0, value: '50', text: '50% SBD / 50% STEEM'},
@@ -68,24 +67,23 @@ class Write extends Component {
 
     const { newPost, clearPost, isUpdating, draft, reset } = this.props;
 
-    if (reset) {
-      clearPost();
-      this.setState({
-        title: '',
-        body: '',
-        tags: '',
-      });
-    }else if (newPost) {
-      this.redirect = '';
-      clearPost();
-    }else if (isUpdating && draft) {
+    if (isUpdating && draft) {
       this.permlink = draft.permlink;
       this.setState({
         title: draft.title,
         body: draft.body,
         tags: draft.jsonMetadata.tags.join(' '),
       });
-    }
+    }else if (reset) {
+      clearPost();
+      this.setState({
+        title: '',
+        body: '',
+        tags: '',
+      });
+    }/*else if (newPost) {
+      clearPost();
+    }*/
   }
 
   componentWillUnmount() {
@@ -237,11 +235,8 @@ class Write extends Component {
         reset,
       }
     } = this;
-
-    if (newPost) {
-      this.redirect = newPost;
-    }
-
+console.log('state',this.state)
+console.log('props',this.props)
     return (
       (newPost && !reset)
       ? <Redirect to={newPost} />

--- a/client/src/components/pages/Steem/Write/Write.js
+++ b/client/src/components/pages/Steem/Write/Write.js
@@ -7,7 +7,7 @@ const Write = () => (
   <Grid verticalAlign='middle' columns={1} centered>
     <Grid.Row>
       <Grid.Column width={13}>
-        <Editor reset />
+        <Editor isNewPost />
       </Grid.Column>
     </Grid.Row>
   </Grid>

--- a/client/src/reducers/commentsReducer.js
+++ b/client/src/reducers/commentsReducer.js
@@ -2,6 +2,8 @@ import {
   GET_COMMENTS_START,
   GET_COMMENTS_SUCCESS,
   CLEAR_COMMENTS,
+  DELETE_COMMENT_START,
+  DELETE_COMMENT_SUCCESS,
 } from '../actions/commentsActions';
 
 /**
@@ -15,6 +17,8 @@ export const comments = (
   state = {
     isFetchingComments: false,
     replies: [],
+    isDeleting: false,
+    commentDeleting: {},
   },
   action) => {
 
@@ -34,6 +38,22 @@ export const comments = (
       return ({
         ...state,
         replies: [],
+      });
+    case DELETE_COMMENT_START:
+      return ({
+        ...state,
+        isDeleting: true,
+        commentDeleting: {
+          author: action.author,
+          permlink: action.permlink,
+        }
+      });
+    case DELETE_COMMENT_SUCCESS:
+      return ({
+        ...state,
+        isDeleting: false,
+        replies: action.newReplies,
+
       });
     default:
       return state

--- a/client/src/reducers/detailsPostReducer.js
+++ b/client/src/reducers/detailsPostReducer.js
@@ -39,6 +39,8 @@ export const detailsPost = (
         ...state,
         isFetchingDetails: false,
         post: {},
+        redirect: '',
+        isDeleting: false,
       });
     case DELETE_POST_START:
       return ({

--- a/client/src/reducers/detailsPostReducer.js
+++ b/client/src/reducers/detailsPostReducer.js
@@ -2,6 +2,8 @@ import {
   GET_DETAILS_START,
   GET_DETAILS_SUCCESS,
   CLEAR_POST,
+  DELETE_POST_START,
+  DELETE_POST_SUCCESS,
 } from '../actions/detailsPostActions';
 
 /**
@@ -15,6 +17,8 @@ export const detailsPost = (
   state = {
     isFetchingDetails: false,
     post: {},
+    isDeleting: false,
+    redirect: '',
   },
   action) => {
 
@@ -35,6 +39,17 @@ export const detailsPost = (
         ...state,
         isFetchingDetails: false,
         post: {},
+      });
+    case DELETE_POST_START:
+      return ({
+        ...state,
+        isDeleting: true,
+      });
+    case DELETE_POST_SUCCESS:
+      return ({
+        ...state,
+        isDeleting: false,
+        redirect: action.redirect,
       });
     default:
       return state

--- a/client/src/reducers/sendCommentReducer.js
+++ b/client/src/reducers/sendCommentReducer.js
@@ -3,7 +3,8 @@ import {
   SEND_COMMENT_SUCCESS,
   EDIT_COMMENT_START,
   EDIT_COMMENT_SUCCESS,
-  DELETE_COMMENT_START,
+  SEND_COMMENT_CLEAR,
+  DELETE_PAYLOAD_SUCCESS,
 } from '../actions/sendCommentActions';
 
 /**
@@ -21,6 +22,7 @@ export const sendComment = (
     editingComment: 0,
     isUpdating: false,
     updatedId: 0,
+    updatedComment: {},
   },
   action) => {
 
@@ -57,10 +59,21 @@ export const sendComment = (
         updatedComment: action.comment,
         updatedId: action.comment.id,
       });
-    case DELETE_COMMENT_START:
+    case SEND_COMMENT_CLEAR:
       return ({
         ...state,
-        isDeleting: true,
+        isCommenting: false,
+        commentedId: 0,
+        commentPayload: {},
+        isUpdating: false,
+        editingComment: 0,
+        updatedComment: {},
+        updatedId: 0,
+      });
+    case DELETE_PAYLOAD_SUCCESS:
+      return ({
+        ...state,
+        commentPayload: action.newCommentPayload,
       });
     default:
       return state

--- a/client/src/reducers/sendCommentReducer.js
+++ b/client/src/reducers/sendCommentReducer.js
@@ -3,6 +3,7 @@ import {
   SEND_COMMENT_SUCCESS,
   EDIT_COMMENT_START,
   EDIT_COMMENT_SUCCESS,
+  DELETE_COMMENT_START,
 } from '../actions/sendCommentActions';
 
 /**
@@ -28,6 +29,7 @@ export const sendComment = (
       return ({
         ...state,
         isCommenting: true,
+        commentedId: action.parentId,
       });
     case SEND_COMMENT_SUCCESS:
       return ({
@@ -54,6 +56,11 @@ export const sendComment = (
         editingComment: 0,
         updatedComment: action.comment,
         updatedId: action.comment.id,
+      });
+    case DELETE_COMMENT_START:
+      return ({
+        ...state,
+        isDeleting: true,
       });
     default:
       return state

--- a/client/src/reducers/sendPostReducer.js
+++ b/client/src/reducers/sendPostReducer.js
@@ -4,7 +4,6 @@ import {
   SEND_POST_ERROR,
   CLEAR_NEW_POST,
   SHOW_EDIT_POST,
-  DELETE_POST_START,
 } from '../actions/sendPostActions';
 
 /**
@@ -60,11 +59,6 @@ export const sendPost = (
         ...state,
         isUpdating: true,
         draft: action.draft,
-      });
-    case DELETE_POST_START:
-      return ({
-        ...state,
-        isDeleting: true,
       });
     default:
       return state

--- a/client/src/reducers/sendPostReducer.js
+++ b/client/src/reducers/sendPostReducer.js
@@ -4,7 +4,6 @@ import {
   SEND_POST_ERROR,
   CLEAR_NEW_POST,
   SHOW_EDIT_POST,
-  CANCEL_EDIT_POST,
   DELETE_POST_START,
 } from '../actions/sendPostActions';
 
@@ -18,10 +17,11 @@ import {
 export const sendPost = (
   state = {
     isPosting: false,
-    newPost: '',
+    newPostRedirect: '',
     error: '',
     isUpdating: false,
     draft: {},
+    updatedId: 0,
   },
   action) => {
 
@@ -30,7 +30,7 @@ export const sendPost = (
       return ({
         ...state,
         isPosting: true,
-        newPost: '',
+        newPostRedirect: '',
         error: '',
       });
     case SEND_POST_ERROR:
@@ -44,13 +44,14 @@ export const sendPost = (
         ...state,
         isPosting: false,
         isUpdating: false,
-        newPost: action.newPost,
+        newPostRedirect: action.redirect,
       });
     case CLEAR_NEW_POST:
       return ({
         ...state,
         isPosting: false,
-        newPost: '',
+        isUpdating: false,
+        newPostRedirect: '',
         error: '',
         draft: {},
       });
@@ -59,13 +60,6 @@ export const sendPost = (
         ...state,
         isUpdating: true,
         draft: action.draft,
-      });
-    case CANCEL_EDIT_POST:
-      return ({
-        ...state,
-        isUpdating: false,
-        draft: {},
-        newPost: '',
       });
     case DELETE_POST_START:
       return ({

--- a/client/src/reducers/sendPostReducer.js
+++ b/client/src/reducers/sendPostReducer.js
@@ -5,6 +5,7 @@ import {
   CLEAR_NEW_POST,
   SHOW_EDIT_POST,
   CANCEL_EDIT_POST,
+  DELETE_POST_START,
 } from '../actions/sendPostActions';
 
 /**
@@ -65,6 +66,11 @@ export const sendPost = (
         isUpdating: false,
         draft: {},
         newPost: '',
+      });
+    case DELETE_POST_START:
+      return ({
+        ...state,
+        isDeleting: true,
       });
     default:
       return state

--- a/client/src/reducers/sendPostReducer.js
+++ b/client/src/reducers/sendPostReducer.js
@@ -64,6 +64,7 @@ export const sendPost = (
         ...state,
         isUpdating: false,
         draft: {},
+        newPost: '',
       });
     default:
       return state

--- a/client/src/reducers/summaryPostReducer.js
+++ b/client/src/reducers/summaryPostReducer.js
@@ -1,6 +1,7 @@
 import {
   GET_SUMMARY_START,
   GET_SUMMARY_SUCCESS,
+  SUMMARY_CANCEL,
 } from '../actions/summaryPostActions';
 
 /**
@@ -12,7 +13,7 @@ import {
  */
 export const summaryPost = (
   state = {
-    isFetchingSummary: false,
+    isFetching: false,
     prevPage: '',
     posts: [],
     hasMore: true,
@@ -25,17 +26,23 @@ export const summaryPost = (
     case GET_SUMMARY_START:
       return ({
         ...state,
-        isFetchingSummary: true,
+        isFetching: true,
       });
     case GET_SUMMARY_SUCCESS:
       return ({
         ...state,
-        isFetchingSummary: false,
+        isFetching: false,
         posts: action.posts,
         hasMore: action.hasMore,
         prevPage: action.prevPage,
         startAuthor: action.startAuthor,
         startPermlink: action.startPermlink,
+      });
+    case SUMMARY_CANCEL:
+      return ({
+        ...state,
+        isFetching: false,
+        prevPage: action.prevPage,
       });
     default:
       return state

--- a/client/src/utils/fetchFunctions.js
+++ b/client/src/utils/fetchFunctions.js
@@ -161,17 +161,27 @@ export const denyUser = (params, csrf) => {
 }
 
 /**
+ *  Call/fetch to change ownership of a community group.
+ *
+ *  @param {object} params Data to pass to server fetch
+ *  @param {string} csrf CSRF token
+ */
+export const changeOwner = (params, csrf) => {
+  return postData('/manage/users/ownership', params, csrf);
+}
+
+/**
  *  Call/fetch for logging.
  *
  *  @param {object} params Data to pass to server fetch
  */
-export const logger = (type, msg) => {
+export const logger = (type, msg, customMsg) => {
   const params = (type === 'error')
     ? ({
         level: 'error',
         message: {
           name: msg.name,
-          message: msg.message,
+          message: customMsg,
           stack: msg.stack
         }
       })

--- a/client/src/variables.css
+++ b/client/src/variables.css
@@ -6,6 +6,10 @@
     --dark-blue: #06578e;
     --main-border: rgba(77, 162, 242, 0.4);
     --main-border-light: rgba(77, 162, 242, 0.1);
+    --green: #21ba45;
+    --dark-green: #198f35;
+    --red: #db2828;
+    --dark-red: #b21e1e;
 
     --soft-black: #202020;
     --charcoal-grey: #363636;
@@ -13,8 +17,8 @@
     --soft-grey: #cacaca;
     --action-grey: rgba(202, 202, 202, 0.8);
     --font-content: "Roboto", "Lato", "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
-    --font-body: Georgia, Helvetica, "PT Sans / PT Serif";
-    /*font-family: 'Source Serif Pro', serif;*/
+    --font-body: "Roboto", "Lato", "Source Sans Pro";
+    /*font-family: Georgia, Helvetica, 'Source Serif Pro', serif;*/
     /*
     "minion pro", Garamond, Georgia, Avenir, Raleway, Lato, Verdana, "Open Sans", "PT Sans / PT Serif"
     */

--- a/client/src/variables.css
+++ b/client/src/variables.css
@@ -13,9 +13,9 @@
     --soft-grey: #cacaca;
     --action-grey: rgba(202, 202, 202, 0.8);
     --font-content: "Roboto", "Lato", "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
-    --font-body: "Roboto", "Lato", Georgia, "PT Sans / PT Serif";
+    --font-body: Georgia, Helvetica, "PT Sans / PT Serif";
     /*font-family: 'Source Serif Pro', serif;*/
     /*
-    Garamond, Georgia, Avenir, Raleway, Lato, Verdana, "Open Sans", "PT Sans / PT Serif"
+    "minion pro", Garamond, Georgia, Avenir, Raleway, Lato, Verdana, "Open Sans", "PT Sans / PT Serif"
     */
 }

--- a/server/routes/api/manage/users.js
+++ b/server/routes/api/manage/users.js
@@ -307,7 +307,7 @@ const denyJoinGroup = (db, next, group, newUser) => {
  */
 router.post('/ownership', async (req, res, next) => {
   const db = req.app.locals.db;
-  let { group, newOwner, user } = req.body;
+  const { group, newOwner, user } = req.body;
 
   //Modify owner of group in DB
   const changedOwnership = await verifyAccess(db, next, group, user, 'ownership', 'modify') && await changeOwnership(db, next, group, newOwner, user);
@@ -362,7 +362,7 @@ const changeOwnership = async (db, next, group, newOwner, user) => {
       db.collection('users').updateOne(
         { user: newOwner },
         {
-          inc:
+          $inc:
           {
             owned_kgroups: 1
           }

--- a/server/routes/api/manage/users.js
+++ b/server/routes/api/manage/users.js
@@ -291,11 +291,100 @@ const denyJoinGroup = (db, next, group, newUser) => {
         }
       }
     )
-
     return true;
   }catch (err) {
     next(err);
   }
 }
+
+/**
+ *  POST route to change the owner of a community group.
+ *  Route: /manage/users/ownership
+ *
+ *  Gets the local DB object, deconstructs the logged in user,
+ *  user to change ownership to, and group.
+ *  Access for user is verified, and then ownership is changed.
+ */
+router.post('/ownership', async (req, res, next) => {
+  const db = req.app.locals.db;
+  let { group, newOwner, user } = req.body;
+
+  //Modify owner of group in DB
+  const changedOwnership = await verifyAccess(db, next, group, user, 'ownership', 'modify') && await changeOwnership(db, next, group, newOwner, user);
+  res.json(changedOwnership || false);
+})
+
+
+/**
+ *  Modify the ownership of a community group.
+ *
+ *  Update the collections that have releveant data for managing the
+ *  community group data. This is the groups (kgroups), access (kgroups_access)
+ *  and users collections.
+ *
+ *  @param {object} db MongoDB Connection
+ *  @param {function} next Express middleware
+ *  @param {string} group Group name to add to
+ *  @param {string} newOwner New owner to give ownership to
+ *  @returns {object} Send inserted object back to frontend for use
+ */
+const changeOwnership = async (db, next, group, newOwner, user) => {
+  try {
+    return new Promise((resolve) => {
+      db.collection('kgroups').updateOne(
+        { name: group },
+        {
+          $set:
+          {
+            owner: newOwner
+          }
+        }
+      )
+
+      db.collection('kgroups_access').updateOne(
+        { group: group, user: newOwner },
+        {
+          $set: {
+            access: 0,
+          }
+        }
+      )
+
+      db.collection('kgroups_access').updateOne(
+        { group: group, user: user },
+        {
+          $set: {
+            access: 3,
+          }
+        }
+      )
+
+      db.collection('users').updateOne(
+        { user: newOwner },
+        {
+          inc:
+          {
+            owned_kgroups: 1
+          }
+        }
+      )
+
+      db.collection('users').updateOne(
+        { user: user },
+        {
+          $inc:
+          {
+            owned_kgroups: -1
+          }
+        }
+      )
+
+      resolve(true);
+    })
+  }catch (err) {
+    next(err);
+  }
+}
+
 
 export default router;

--- a/server/utils/verifyAccess.js
+++ b/server/utils/verifyAccess.js
@@ -28,6 +28,8 @@ export const verifyAccess = async (db, next, group, user, section, action) => {
     if (section === 'post' && access.access < 3) return true;
     if (section === 'user' && access.access < 2) return true;
     if (section === 'pending' && access.access < 3) return true;
+  }else if (action === 'modify') {
+    if (section === 'ownership' && access.access === 0) return true;
   }
 
   return false;


### PR DESCRIPTION
# What's new

---
- Added deleting of posts

To delete a post, open the post in question, and if it's possible, you will see an X icon button at the bottom right of content of the post.

If you hover over the icon, it will say 'Del' and turn red. It will also display a title of "Delete post". When you click the button, a confirmation popup appears to make sure you really want to delete the post. After confirming, the post will get dimmed and a loading spinner will appear while the post deletion is being processed into the Steem blockchain.

Afterwards, you will be redirected to your main "blog" page and will see the post is gone. The post deleting was much more simple than the comment deletion.

In order to see the delete option, a check is made for the active votes and the comment count. If there are none of both, then the delete option is possible. The author and permlink are sent in the onClick for the button.

In the Redux action creator, the author and permlink are used to delete the post. Once completed, the user is redirected to their own blog page to see the post gone.

---
- Added deleting of comments

To delete a comment, view the comment in question on the post, and if it's possible, you will see a 'Delete' link at the bottom of the comment.

When you click the 'Delete' link, a confirmation popup appears to make sure you really want to delete the post. After confirming, wait about 3 seconds and the comment will disappear.

Getting the comment deleted starts off in the same way as the post, but gets more complex to remove it from the view in the app without a page refresh or refetching all the comments again. Refetching the comment data would have been quicker, and maybe it's less resource demanding as well.

The author and permlink are sent to the Redux action creator to delete.

As you can see, there is more code here. First, the comment is deleted from Steem. Then, if successful, if the comment is new and was just added and wasn't part of the original page load, a quick check is made in the `commentPayload` object and the comment is filtered out.

If the comment isn't there, then a look is made in the comments that were part of the page loading to look into the nested comment and recursively delete them. This brings us to the recursive function, where all the replies are dug into to try to find the comment we want to delete. If found, it's filtered out.

---
- Added Transfer Ownership option to owned community groups

In the `Manage` page for managing community groups, you can transfer ownership of a group you own. Click on the Edit icon.

When the `Managing` section opens up, there is the new section called `Transfer Ownership`. Type in the name of a user. They must already be in the community in order to receive ownership. If they aren't add them first, then click on `Transfer`. After the transfer is done, you will see the group change location, from `Communities You Own` to `Communities You Joined`. Now you are no longer the owner, but are still a member of the group.

---
- Eye Candy on Post Actions

There has been some eye candy animated effect added for the post actions, which include deleting a post. Edit a post will show an edit icon, and hovering over it will animate the Edit text. Delete a post will show an X icon, and hovering over it will animate the Del text. Adding a post to a community will show a + icon, and hovering over it will animate the Add text.

---
# Bug Fixes

---
- Fixed bug of spinner stuck on community page with no posts

A bug was introduced with some previous code changes, where the community page with no current posts was not showing the basic layout of no posts, members, and the name of the group. I was checking for posts in order to display, which was a blunder, since sometimes there are no posts.

Grabbing the kposts.length when there were no posts made the loading spinner stay forever. Correcting that to instead look for the group's display name meant that the group data would show up even if there were no posts, which is what is required.

---
- Fixed loading spinner staying on blog page with no posts

When a Steem blog page was loaded, but there were no posts, the loading spinner was also staying stuck. When I merged pages I added several fetches at first, but they became useless and I refined the code.

I had a fetch for the scroll which was no longer being used, but checked and would not show the `No Posts` message as a result. Removing the useless fetch corrected the issue and now blog pages with no posts will show a simple `No Posts` message.


---
- Fixed comment form disabled by default

When I merged the ReplyForm with the EditForm, I also merged the `disabled` flag, but erroneously used it to disable the text area itself. By not using the merged disabled flag, and instead using the isCommenting flag alone, the text area was active and working again.

---
- Fixed spinner not showing when sending comment

Another loading spinner bug, but this time for it not showing. When I created the send comment Redux actions, I forgot to pass in the parent ID which was used in my app to determine if a comment was being commented on. After adding the `parentId` field to the reducer, the comment being sent had the loading action present.


---
- Fixed editing posts not updating changes in view

When I made the editing posts functionality, it worked, but the changes to anything other than the body were not visibly seen afterwards. This means when changing the title or tags, they weren't seen afterwards.

To resolve that, I went and grabbed the content of the post when an update was made to the `Post` component, but only when there was a draft, and when the new draft object wasn't the same as the one before.

---
- Fixed join request not working since move to redux

After moving Join Requests to Redux, you could see Join, but when trying to join, nothing happened. This is now working again after I fixed the way data is obtained using the Redux state.

I didn't account for the reducer when I was trying to get the data. As a result, I was getting undefined data, instead of the actual data. After specifying the `communities` reducer, the data was present and everything was working again as it did prior to moving to Redux.

---
- Fixed permissions not updated in view after ownership transfer

When transferring a community's ownership to some one else, the membership view was not updated to reflect these changes. I fixed it by updating the `users` state object to change the membership for the logged in user, setting them as a Member instead of an Owner, and set the newOwner as Owner.

---
- Fixed the view not moving transferred community to joined section

The view for the Own and Join communities views was not updated when transferring a community to another owner. So after a transfer, the community still showed in the Own area, rather than Joined.

Instead of manipulating the data across various level of the component hierarchy, I opted to simply go fetch the data again which would be less complicated and less resource demanding. Now when ownership is transferred, a call is made to the top level parent to simply call the data again and propagate it through props to the child components.